### PR TITLE
[feature] sharpen personal positioning copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ This project is a satirical product launch for Matteo Bianchi: a personal portfo
 
 - A product-spec hero built around a real speaking photo
 - An asymmetric capability manifest covering platform engineering, Solutions Engineering, AI automation, and open-source education
-- An interactive hiring compatibility lab with accessible default content
+- An interactive compatibility lab with accessible default content
 - The original `main` branch “loved by” logo set plus GitHub, Replit, OpenAI, and Anthropic, upgraded into an accessible animated runway
 - Homepage runway logos are bundled locally and loaded eagerly so marquee motion never reveals unloaded placeholders
 - An open-source proof ledger sourced from `src/data/projects.json`
 - A complete route system for field notes, changelog, portfolio, deployment history, pricing, legal, and support pages
 - Original high-resolution organisation logos with a clean KubeLab monogram fallback throughout Customers
 - Verifiable contribution, speaking, and project benchmarks
-- Satirical release notes and direct hiring calls to action
+- Satirical release notes and direct trial calls to action
 
 ## 🎯 Purpose
 
@@ -33,7 +33,7 @@ This project was created to:
 
 - **Responsive design** that works on mobile and desktop
 - **Modern React components** with TypeScript
-- **Interactive hiring diagnostics** with semantic buttons and live results
+- **Interactive compatibility diagnostics** with semantic buttons and live results
 - **Server-side rendering** with Next.js 15
 - **Static-exported route system** with route-specific metadata and useful no-JavaScript defaults
 - **CSS Modules** for the homepage, global shell, and shared inner-page system

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 ## 🚀 About
 
-This project is a satirical product launch for Matteo Bianchi: a personal portfolio disguised as the kind of overconfident startup landing page the tech industry keeps producing. The joke leads; real cloud-native work, open-source projects, talks, and product-minded engineering provide the reveal.
+This project is a satirical product launch for Matteo Bianchi: a personal portfolio disguised as the kind of overconfident startup landing page the tech industry keeps producing. The joke leads; senior engineering across platforms, solutions, software, and AI provides the reveal.
 
-"Matteo" serves as the fictional product/platform, but the capabilities and evidence point to a real engineer:
+"Matteo" serves as the fictional product/platform, but the capabilities and evidence point to a real engineer who connects deep implementation, customer needs, automation, open source, and communication:
 
 - A product-spec hero built around a real speaking photo
-- An asymmetric capability manifest instead of a resume timeline
+- An asymmetric capability manifest covering platform engineering, Solutions Engineering, AI automation, and open-source education
 - An interactive hiring compatibility lab with accessible default content
 - The original `main` branch “loved by” logo set plus GitHub, Replit, OpenAI, and Anthropic, upgraded into an accessible animated runway
 - Homepage runway logos are bundled locally and loaded eagerly so marquee motion never reveals unloaded placeholders
@@ -23,10 +23,10 @@ This project is a satirical product launch for Matteo Bianchi: a personal portfo
 
 This project was created to:
 
-1. Turn a professional portfolio into a memorable product narrative
+1. Turn a broad senior-engineering profile into a memorable, coherent product narrative
 2. Demonstrate production-grade Next.js component and interaction design
 3. Highlight the formulaic nature of startup marketing without becoming another generic SaaS page
-4. Connect bold claims to inspectable open-source and community evidence
+4. Connect bold claims to measurable career outcomes plus inspectable open-source and community evidence
 5. Show conversion from static HTML/CSS/JS to modern React + Next.js
 
 ## 🔍 Key Features

--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Product Internals — Matteo',
-  description: 'Mission, operating principles, community work, and the many roles inside the Matteo human platform.',
+  description: 'How Matteo combines platform engineering, Solutions Engineering, AI automation, software, open source, and technical education.',
 }
 
 export default function AboutLayout({

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,53 +6,53 @@ import styles from '@/app/inner.module.css'
 
 const mission = [
   {
-    title: 'Build work that matters',
-    description: 'Choose meaningful systems over decorative complexity and optimise for durable human outcomes.',
+    title: 'Start with real friction',
+    description: 'Understand the developer or customer workflow before choosing the platform, product surface, or automation.',
   },
   {
-    title: 'Make engineers stronger',
-    description: 'Share the knowledge, context, and tooling that helps other people ship with more confidence.',
+    title: 'Automate for leverage',
+    description: 'Use AI and software to remove repeated work while keeping judgment, ownership, and observability with people.',
   },
   {
-    title: 'Keep open source open',
-    description: 'Contribute upstream, teach in public, and return value to the communities that made the work possible.',
+    title: 'Engineer for adoption',
+    description: 'Treat interfaces, documentation, enablement, and feedback loops as part of the system—not post-launch chores.',
   },
   {
-    title: 'Remove avoidable friction',
-    description: 'Turn repetitive platform work into understandable products, paved roads, and useful automation.',
+    title: 'Compound in public',
+    description: 'Contribute upstream, teach what works, and turn hard-won lessons into reusable open-source and community value.',
   },
 ]
 
 const departments = [
   {
-    name: 'CEO mode',
-    role: 'Direction',
-    description: 'Finds the useful problem and keeps the ambition attached to reality.',
+    name: 'Platform mode',
+    role: 'Systems',
+    description: 'Builds cloud infrastructure, Kubernetes platforms, paved roads, and reliability into a usable developer product.',
   },
   {
-    name: 'CTO mode',
-    role: 'Architecture',
-    description: 'Connects product intent to systems, trade-offs, and technical execution.',
+    name: 'Solutions mode',
+    role: 'Customers',
+    description: 'Connects discovery, architecture, demos, delivery, and field feedback without losing technical credibility.',
   },
   {
-    name: 'Engineer mode',
+    name: 'AI mode',
+    role: 'Automation',
+    description: 'Turns repeated workflows into assistants, agents, and tools with measurable outcomes and human ownership.',
+  },
+  {
+    name: 'Software mode',
     role: 'Delivery',
-    description: 'Builds the thing, debugs the thing, and documents why the thing exists.',
+    description: 'Ships APIs, CLIs, services, and product interfaces across Go, Python, TypeScript, Rust, and React.',
   },
   {
-    name: 'DevRel mode',
-    role: 'Adoption',
-    description: 'Turns difficult technology into material people can understand and reuse.',
-  },
-  {
-    name: 'Advisor mode',
+    name: 'Open-source mode',
     role: 'Leverage',
-    description: 'Helps teams see the second-order consequences before they become incidents.',
+    description: 'Contributes upstream, maintains release infrastructure, and helps companies build credible open-source strategy.',
   },
   {
-    name: 'Community mode',
-    role: 'Multiplication',
-    description: 'Creates rooms, talks, and open work where other engineers can grow.',
+    name: 'Education mode',
+    role: 'Adoption',
+    description: 'Uses talks, workshops, mentorship, and documentation to make complex technology understandable and reusable.',
   },
 ]
 
@@ -79,13 +79,13 @@ export default function About() {
     <div className={styles.page}>
       <PageHero
         path="/about"
-        title="Product internals. One human, several subsystems."
-        description="The startup is fictional. The mission, operating principles, community work, and unreasonable number of hats are all real."
+        title="Product internals. Deep engineering with customer-facing interfaces."
+        description="The startup is fictional. The operating model is real: build the system, translate the need, automate repeated work, and make the knowledge travel."
         tone="dark"
         actions={
           <>
             <Link href="#mission" className={styles.primaryButton}>
-              Read the mission
+              Read the operating principles
               <span aria-hidden="true">↓</span>
             </Link>
             <Link href="#community" className={styles.secondaryButton}>
@@ -112,7 +112,7 @@ export default function About() {
         <div className={styles.sectionInner}>
           <div className={styles.sectionIntro}>
             <h2 id="mission-title">Mission parameters.</h2>
-            <p>What the product metaphor is trying to say when it stops being funny for a minute.</p>
+            <p>What the product metaphor means when it stops being funny for a minute.</p>
           </div>
           <div className={styles.manifesto}>
             {mission.map((item) => (
@@ -129,11 +129,11 @@ export default function About() {
         <div className={styles.sectionInner}>
           <p>Long-range operating intent</p>
           <h2 id="vision-title">
-            Make complex systems easier to build, easier to explain, and easier for other people to improve.
+            Build systems that solve the technical problem, earn adoption, and leave the team stronger.
           </h2>
           <p>
-            Open collaboration, trust, and creative engineering should compound. The goal is not to look innovative;
-            it is to help useful ideas travel farther.
+            The best work connects engineering depth, customer signal, automation, and communication.
+            The goal is not to look cross-functional; it is to make those capabilities compound.
           </p>
         </div>
       </section>
@@ -172,8 +172,8 @@ export default function About() {
       <section className={styles.sectionSoft} aria-labelledby="departments-title">
         <div className={styles.sectionInner}>
           <div className={styles.sectionIntro}>
-            <h2 id="departments-title">One human, six departments.</h2>
-            <p>The old page duplicated the portrait. This version duplicates the responsibilities instead.</p>
+            <h2 id="departments-title">One human, six operating modes.</h2>
+            <p>Different contexts, shared architecture, no interdepartmental ticket required.</p>
           </div>
           <div className={styles.departmentGrid}>
             {departments.map((department) => (

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -57,7 +57,7 @@ export default function CareersPage() {
             rel="noopener noreferrer"
             className={styles.darkButton}
           >
-            Start a hiring conversation
+            Start trial
             <span aria-hidden="true">↗</span>
           </a>
         }
@@ -129,7 +129,7 @@ export default function CareersPage() {
           rel="noopener noreferrer"
           className={styles.darkButton}
         >
-          Start the interview loop
+          Start trial
           <span aria-hidden="true">↗</span>
         </a>
       </section>

--- a/src/app/careers/page.tsx
+++ b/src/app/careers/page.tsx
@@ -4,42 +4,42 @@ import styles from '@/app/inner.module.css'
 
 export const metadata: Metadata = {
   title: 'Careers — Matteo',
-  description: 'The engineering, product, platform, DevRel, and solutions careers bundled into one human.',
+  description: 'Matteo is actively seeking senior platform, solutions, software, and AI engineering roles with strong open-source and community impact.',
 }
 
 const roles = [
   {
-    title: 'Developer Advocate',
-    description: 'Technical content, conference talks, community feedback, demos, and developer experience work.',
-    skills: ['Technical writing', 'Public speaking', 'Community', 'DevEx'],
+    title: 'Senior Platform Engineer',
+    description: 'Developer platforms, Kubernetes, infrastructure as code, reliability, and self-service workflows designed around adoption.',
+    skills: ['Platform engineering', 'Kubernetes', 'IaC', 'SRE'],
   },
   {
-    title: 'Product Manager, Kubernetes edition',
-    description: 'Product strategy, user discovery, platform positioning, and translating cloud-native complexity into choices.',
-    skills: ['Kubernetes', 'Product strategy', 'Research', 'Launches'],
+    title: 'Solutions Engineer, Technical Products',
+    description: 'Customer discovery, architecture, demos, proof of value, implementation guidance, and field insight that improves the product.',
+    skills: ['Discovery', 'Architecture', 'Demos', 'GTM'],
   },
   {
     title: 'Senior Software Engineer',
-    description: 'Typed interfaces, automation, APIs, system design, and enough implementation detail to keep strategy honest.',
-    skills: ['Go', 'Python', 'TypeScript', 'System design'],
+    description: 'APIs, services, CLIs, product interfaces, automation, and system design across Go, Python, TypeScript, Rust, and React.',
+    skills: ['Go', 'Python', 'TypeScript', 'Rust'],
   },
   {
-    title: 'Staff Platform Engineer',
-    description: 'Golden paths, infrastructure as code, distributed systems, and technical leadership across teams.',
-    skills: ['Platform engineering', 'IaC', 'Kubernetes', 'Leadership'],
+    title: 'AI Engineer, Developer Automation',
+    description: 'Agents, assistants, MCP integrations, and workflow automation built around measurable work rather than novelty.',
+    skills: ['AI agents', 'MCP', 'Automation', 'Evaluation'],
   },
   {
-    title: 'Solutions Engineer',
-    description: 'Customer context, technical discovery, architecture, and turning product capability into a credible path forward.',
-    skills: ['Discovery', 'Cloud architecture', 'Demos', 'Problem solving'],
+    title: 'Open Source & Community Lead',
+    description: 'Upstream contribution, open-source strategy, technical education, speaking, mentorship, and community feedback loops.',
+    skills: ['Open source', 'Speaking', 'Training', 'Community'],
   },
 ]
 
 const principles = [
-  ['Transparency', 'Show the trade-off, the source, and the work still left to do.'],
-  ['Integrity', 'Make the honest technical recommendation even when the flashy answer sells better.'],
-  ['Reliability', 'Treat follow-through as part of the architecture.'],
-  ['Creativity', 'Use constraints as material, not an excuse for generic output.'],
+  ['Customer signal', 'Understand the workflow and the stakes before prescribing the system.'],
+  ['Technical depth', 'Stay close enough to implementation that strategy survives contact with reality.'],
+  ['Leverage', 'Automate repeated work and build tools that make the whole team stronger.'],
+  ['Communication', 'Make trade-offs clear enough for engineers, leaders, customers, and communities to act on.'],
 ]
 
 export default function CareersPage() {
@@ -47,8 +47,8 @@ export default function CareersPage() {
     <div className={styles.page}>
       <PageHero
         path="/careers"
-        title="One opening. Five jobs worth of surface area."
-        description="This is not a recruiting page. It is the role manifest for what a company gets when it deploys Matteo."
+        title="Now accepting one full-time deployment."
+        description="Best fit: a senior role at the intersection of platform engineering, technical products, software, and practical AI—with open source and communication built in."
         tone="cyan"
         actions={
           <a
@@ -57,23 +57,23 @@ export default function CareersPage() {
             rel="noopener noreferrer"
             className={styles.darkButton}
           >
-            Start the interview loop
+            Start a hiring conversation
             <span aria-hidden="true">↗</span>
           </a>
         }
         aside={
           <dl className={styles.heroSpecs}>
             <div>
-              <dt>Headcount</dt>
-              <dd>1 human</dd>
+              <dt>Availability</dt>
+              <dd>Actively interviewing</dd>
             </div>
             <div>
-              <dt>Role coverage</dt>
-              <dd>{roles.length} operating modes</dd>
+              <dt>Primary model</dt>
+              <dd>Full-time</dd>
             </div>
             <div>
-              <dt>Management overhead</dt>
-              <dd>Suspiciously low</dd>
+              <dt>Consulting</dt>
+              <dd>Selective</dd>
             </div>
           </dl>
         }
@@ -82,8 +82,8 @@ export default function CareersPage() {
       <section className={styles.sectionDark} aria-labelledby="roles-title">
         <div className={styles.sectionInner}>
           <div className={styles.sectionIntro}>
-            <h2 id="roles-title">Careers included in the base image.</h2>
-            <p>Not simultaneous job titles. A range of contexts the same product-minded engineer can handle.</p>
+            <h2 id="roles-title">Supported deployment targets.</h2>
+            <p>Not five simultaneous titles. Five contexts where the same engineering system creates leverage.</p>
           </div>
           <div className={styles.roleList}>
             {roles.map((role) => (
@@ -121,7 +121,7 @@ export default function CareersPage() {
       <section className={styles.careersClose}>
         <div>
           <p>Compatibility looks promising.</p>
-          <h2>Now test the human interface.</h2>
+          <h2>If these capabilities need to reinforce each other, test the human interface.</h2>
         </div>
         <a
           href="https://cal.com/mbianchidev/intro"
@@ -129,7 +129,7 @@ export default function CareersPage() {
           rel="noopener noreferrer"
           className={styles.darkButton}
         >
-          Book a live demo
+          Start the interview loop
           <span aria-hidden="true">↗</span>
         </a>
       </section>

--- a/src/app/home.module.css
+++ b/src/app/home.module.css
@@ -965,9 +965,10 @@
 .primaryBenchmark > span {
     color: var(--primary-color);
     font-family: var(--font-display);
-    font-size: clamp(5rem, 10vw, 9rem);
+    font-size: clamp(3.9rem, 7vw, 7rem);
     line-height: 0.8;
     letter-spacing: -0.04em;
+    white-space: nowrap;
 }
 
 .primaryBenchmark p {
@@ -991,7 +992,7 @@
 
 .benchmarkList > div {
     display: grid;
-    grid-template-columns: 120px 1fr;
+    grid-template-columns: minmax(170px, 0.42fr) minmax(0, 1fr);
     gap: 28px;
     align-items: center;
     padding: 32px clamp(28px, 4vw, 50px);
@@ -1005,15 +1006,17 @@
 .benchmarkList dt {
     color: var(--accent-color);
     font-family: var(--font-display);
-    font-size: clamp(2.5rem, 4vw, 4rem);
+    font-size: clamp(2.5rem, 3.4vw, 3.6rem);
     line-height: 1;
     letter-spacing: -0.035em;
+    white-space: nowrap;
 }
 
 .benchmarkList dd {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    min-width: 0;
 }
 
 .benchmarkList strong {
@@ -1401,7 +1404,7 @@
     }
 
     .benchmarkList > div {
-        grid-template-columns: 92px 1fr;
+        grid-template-columns: minmax(124px, auto) minmax(0, 1fr);
         gap: 20px;
         padding: 26px 22px;
     }

--- a/src/app/inner.module.css
+++ b/src/app/inner.module.css
@@ -1310,6 +1310,7 @@
 .pricingPlan {
     display: flex;
     flex-direction: column;
+    min-width: 0;
     min-height: 560px;
     padding: 28px;
     color: var(--bg-primary);
@@ -1324,10 +1325,13 @@
 }
 
 .planHeader {
-    display: flex;
-    justify-content: space-between;
-    gap: 20px;
-    align-items: flex-start;
+    display: grid;
+    gap: 18px;
+    align-content: start;
+}
+
+.planHeader > div:first-child {
+    min-width: 0;
 }
 
 .planHeader p {
@@ -1340,21 +1344,26 @@
     margin: 0;
     color: var(--bg-primary);
     font-family: var(--font-display);
-    font-size: clamp(2rem, 3.6vw, 3.2rem);
+    font-size: clamp(2rem, 3vw, 2.9rem);
     font-weight: 400;
     line-height: 1;
     letter-spacing: -0.03em;
+    hyphens: none;
+    overflow-wrap: normal;
+    word-break: normal;
 }
 
 .planPrice {
     display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    text-align: right;
+    gap: 7px;
+    align-items: baseline;
+    min-width: 0;
+    text-align: left;
 }
 
 .planPrice strong {
     font-size: clamp(1.35rem, 2.4vw, 2rem);
+    white-space: nowrap;
 }
 
 .planPrice span {
@@ -1897,15 +1906,6 @@
 
     .historyHeader {
         flex-direction: column;
-    }
-
-    .planHeader {
-        flex-direction: column;
-    }
-
-    .planPrice {
-        align-items: flex-start;
-        text-align: left;
     }
 
     .pricingPlan > p {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { Footer } from '@/components/Footer'
 export const metadata: Metadata = {
   applicationName: 'Matteo',
   title: 'Matteo — The Human Platform',
-  description: 'A product-shaped portfolio for Matteo Bianchi: platform engineering, cloud-native systems, open source, and technical storytelling.',
+  description: 'Matteo Bianchi is a Senior Engineer across platforms, solutions, software, and AI, combining deep engineering with customer insight, open source, and technical communication.',
   appleWebApp: {
     capable: true,
     title: 'Matteo',

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -7,7 +7,7 @@ import styles from '@/app/inner.module.css'
 
 export const metadata: Metadata = {
   title: 'Open Source — Matteo',
-  description: 'Creator-owned projects and contributions across the cloud-native ecosystem.',
+  description: 'Creator-owned projects and upstream contributions across developer platforms, AI tooling, Kubernetes, infrastructure, and education.',
 }
 
 const ownedProjects = projectsData.projects.filter((project) => {
@@ -28,7 +28,7 @@ export default function Portfolio() {
       <PageHero
         path="/portfolio"
         title="Source available. Claims inspectable."
-        description="Projects created, maintained, and contributed to across platform engineering, Kubernetes, infrastructure as code, and developer tooling."
+        description="Projects created, maintained, and contributed to across developer platforms, AI tooling, Kubernetes, infrastructure, and technical education."
         tone="green"
         actions={
           <>

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -158,16 +158,16 @@ export default function Portfolio() {
               <dd>Merged Kubernetes pull requests</dd>
             </div>
             <div>
-              <dt>22+</dt>
+              <dt>20+</dt>
               <dd>Talks and workshops delivered</dd>
             </div>
             <div>
-              <dt>{postCount}</dt>
-              <dd>Published field notes</dd>
+              <dt>500+</dt>
+              <dd>Learners trained</dd>
             </div>
             <div>
-              <dt>10+</dt>
-              <dd>Years shipping production systems</dd>
+              <dt>15+</dt>
+              <dd>Mentees coached · 5/5 stars</dd>
             </div>
           </dl>
         </div>

--- a/src/app/pricing/layout.tsx
+++ b/src/app/pricing/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Pricing — Matteo',
-  description: 'Transparent advisory, delivery, and full-time engagement options.'
+  description: 'Full-time hiring plus selective Kubernetes, open-source strategy, mentorship, training, and speaking engagements.'
 }
 
 export default function PricingLayout({

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -19,47 +19,48 @@ const pricingPlans: PricingPlan[] = [
   {
     id: 'advisory',
     name: 'Advisory',
-    description: 'Focused architecture, product, platform, or cloud-native decisions without pretending a slide deck is delivery.',
+    description: 'Focused Kubernetes and open-source decisions for teams that need an experienced second brain before they need another implementation team.',
     price: '€100',
     hourlyRate: 100,
     period: '/hour',
     features: [
-      'Architecture and platform review',
-      'Cloud-native strategy',
-      'Developer experience feedback',
-      'Technical product positioning',
+      'Kubernetes architecture and readiness review',
+      'Performance, reliability, and cost assessment',
+      'Open-source strategy and governance',
+      'Platform and developer experience feedback',
       'Written recommendations',
       'No mandatory transformation programme',
     ],
   },
   {
     id: 'delivery',
-    name: 'Delivery',
-    description: 'Hands-on engineering and product work for teams that need the recommendation implemented, tested, and adopted.',
+    name: 'Delivery & enablement',
+    description: 'Hands-on Kubernetes work, technical education, and adoption support for teams that need the recommendation implemented and understood.',
     price: '€150',
     hourlyRate: 150,
     period: '/hour',
-    recommended: true,
     features: [
       'Everything in Advisory',
-      'Platform and cloud implementation',
-      'Typed product interfaces and CLIs',
-      'Automation, CI/CD, and infrastructure as code',
-      'Documentation and enablement',
-      'Direct feedback loops with users',
+      'Kubernetes and platform implementation',
+      'Mentorship for engineers and technical leaders',
+      'Custom training and workshops',
+      'Conference and internal speaking',
+      'Documentation and adoption support',
     ],
   },
   {
     id: 'full-time',
     name: 'Full-time',
-    description: 'The complete human-platform deployment for companies hiring a product-minded senior engineer.',
+    description: 'The primary human-platform deployment for companies hiring a senior engineer across platforms, solutions, software, and AI.',
     price: 'Let’s talk',
     period: '',
+    recommended: true,
     features: [
       'All operating modes included',
-      'Long-term product and system ownership',
-      'Platform, cloud, DevEx, and technical storytelling',
-      'Open-source and community leverage',
+      'Long-term product, customer, and system ownership',
+      'Platform, cloud, software, and AI delivery',
+      'Solutions Engineering and field feedback',
+      'Open-source, education, and community leverage',
       'No seat-based pricing',
       'Coffee dependency remains customer-managed',
     ],
@@ -94,8 +95,8 @@ export default function Pricing() {
     <div className={styles.page}>
       <PageHero
         path="/pricing"
-        title="Transparent pricing. Extremely negotiable acquisition model."
-        description="Hourly advisory and delivery rates for the consulting version. Companies hiring the full product should skip directly to the human conversation."
+        title="Full-time first. Consulting endpoints still available."
+        description="The primary deployment is a senior full-time role. Limited consulting remains available for Kubernetes, open-source strategy, mentorship, training, and speaking."
         tone="dark"
         actions={
           <a
@@ -104,23 +105,23 @@ export default function Pricing() {
             rel="noopener noreferrer"
             className={styles.primaryButton}
           >
-            Request a quote
+            Discuss a deployment
             <span aria-hidden="true">↗</span>
           </a>
         }
         aside={
           <dl className={styles.heroSpecs}>
             <div>
-              <dt>Hidden fees</dt>
-              <dd>None</dd>
+              <dt>Primary plan</dt>
+              <dd>Full-time</dd>
+            </div>
+            <div>
+              <dt>Consulting</dt>
+              <dd>Selective</dd>
             </div>
             <div>
               <dt>Seat pricing</dt>
               <dd>Physically impossible</dd>
-            </div>
-            <div>
-              <dt>Enterprise plan</dt>
-              <dd>Hire the human</dd>
             </div>
           </dl>
         }
@@ -129,8 +130,8 @@ export default function Pricing() {
       <section className={styles.sectionLight} aria-labelledby="plans-title">
         <div className={styles.sectionInner}>
           <div className={styles.sectionIntro}>
-            <h2 id="plans-title">Choose an engagement shape.</h2>
-            <p>The tiers are a useful framing device, not a substitute for scoping the actual work.</p>
+            <h2 id="plans-title">Choose a deployment model.</h2>
+            <p>Full-time is the default. The consulting tiers are deliberately narrower.</p>
           </div>
           <div className={styles.pricingGrid}>
             {pricingPlans.map((plan) => {
@@ -265,7 +266,7 @@ export default function Pricing() {
                   <dd>€{dailyCost}</dd>
                 </div>
               </dl>
-              <p>Final quote depends on scope, context, risk, and whether the problem is actually Kubernetes.</p>
+              <p>Final quote depends on scope, context, risk, and whether Kubernetes is actually the right answer.</p>
             </div>
           </div>
         </div>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -51,7 +51,7 @@ const pricingPlans: PricingPlan[] = [
   {
     id: 'full-time',
     name: 'Full-time',
-    description: 'The primary human-platform deployment for companies hiring a senior engineer across platforms, solutions, software, and AI.',
+    description: 'The primary human-platform deployment for companies adding a senior engineer across platforms, solutions, software, and AI.',
     price: 'Let’s talk',
     period: '',
     recommended: true,
@@ -182,7 +182,7 @@ export default function Pricing() {
                     rel="noopener noreferrer"
                     className={plan.recommended ? styles.darkButton : styles.lightButton}
                   >
-                    {plan.id === 'full-time' ? 'Start a hiring conversation' : 'Scope this engagement'}
+                    {plan.id === 'full-time' ? 'Start trial' : 'Scope this engagement'}
                     <span aria-hidden="true">↗</span>
                   </a>
                 </article>

--- a/src/components/Benchmarks.tsx
+++ b/src/components/Benchmarks.tsx
@@ -2,19 +2,19 @@ import styles from '@/app/home.module.css'
 
 const benchmarks = [
   {
-    value: '22+',
-    label: 'talks and workshops delivered',
-    source: 'Sessionize and event history'
+    value: '121%',
+    label: 'quota reached in the first eight months at GitHub',
+    source: 'Corporate Solutions Engineering, EMEA'
   },
   {
-    value: '10+',
-    label: 'years shipping production systems',
-    source: 'Field-tested since 2015'
+    value: '70+',
+    label: 'engineers enabled by platform APIs and zero-touch onboarding',
+    source: 'Six product teams'
   },
   {
-    value: '111',
-    label: 'stars on the Platform Engineering Roadmap',
-    source: 'GitHub repository signal'
+    value: '300+',
+    label: 'people trained in Platform Engineering and Kubernetes',
+    source: '95% surveyed CSAT'
   }
 ]
 
@@ -23,13 +23,13 @@ export function Benchmarks() {
     <section className={styles.benchmarks} aria-labelledby="benchmarks-title">
       <div className={styles.benchmarkIntro}>
         <h2 id="benchmarks-title">Field report, not vanity dashboard.</h2>
-        <p>Numbers are not ARR. They are actual output.</p>
+        <p>Selected outcomes from the current production history.</p>
       </div>
       <div className={styles.report}>
         <div className={styles.primaryBenchmark}>
-          <span>40+</span>
-          <p>merged Kubernetes pull requests</p>
-          <small>Personal contribution, not project popularity.</small>
+          <span>20–25%</span>
+          <p>recurring Solutions Engineering work automated</p>
+          <small>Internal AI assistant. Human judgment and customer ownership retained.</small>
         </div>
         <dl className={styles.benchmarkList}>
           {benchmarks.map((benchmark) => (

--- a/src/components/Benchmarks.tsx
+++ b/src/components/Benchmarks.tsx
@@ -2,9 +2,9 @@ import styles from '@/app/home.module.css'
 
 const benchmarks = [
   {
-    value: '121%',
-    label: 'quota reached in the first eight months at GitHub',
-    source: 'Corporate Solutions Engineering, EMEA'
+    value: '180%',
+    label: 'quota reached at GitHub',
+    source: 'Club FY26 winner · Corporate Solutions Engineering, EMEA'
   },
   {
     value: '70+',
@@ -12,9 +12,9 @@ const benchmarks = [
     source: 'Six product teams'
   },
   {
-    value: '300+',
-    label: 'people trained in Platform Engineering and Kubernetes',
-    source: '95% surveyed CSAT'
+    value: '500+',
+    label: 'learners trained in Platform Engineering and Kubernetes',
+    source: '20+ talks · 15+ mentees · 5/5 stars as a mentor'
   }
 ]
 

--- a/src/components/Capabilities.tsx
+++ b/src/components/Capabilities.tsx
@@ -15,7 +15,7 @@ const capabilities = [
     key: 'solutions.interface',
     title: 'Customer problems translated into shipped systems',
     description:
-      'Connects technical discovery, architecture, demos, field feedback, and hands-on delivery. Reached 121% quota in the first eight months at GitHub.',
+      'Connects technical discovery, architecture, demos, field feedback, and hands-on delivery. Won Club FY26 after reaching 180% quota at GitHub.',
     signal: 'Solutions engineering · discovery · GTM · product feedback',
     evidence: 'Review deployment history',
     href: '/customers'
@@ -33,7 +33,7 @@ const capabilities = [
     key: 'open.protocol',
     title: 'Open source and communication that compound',
     description:
-      'Kubernetes release engineering maintainer, 40+ merged upstream pull requests, 22+ talks, and 300+ learners trained with 95% surveyed CSAT.',
+      'Kubernetes release engineering maintainer, 40+ merged upstream pull requests, 20+ talks, 500+ learners, and 15+ mentees coached to success (5/5 stars as a mentor).',
     signal: 'Kubernetes · OSS strategy · speaking · education',
     evidence: 'Open community interfaces',
     href: '/about#community'
@@ -45,7 +45,7 @@ export function Capabilities() {
     <section id="features" className={styles.capabilities} aria-labelledby="capabilities-title">
       <div className={styles.sectionHeader}>
         <p className={styles.sectionCode}>matteo.features()</p>
-        <h2 id="capabilities-title">One hire. Four systems that reinforce each other.</h2>
+        <h2 id="capabilities-title">One deployment. Four systems that reinforce each other.</h2>
         <p>
           The startup framing is a joke. The cross-functional leverage is not.
         </p>

--- a/src/components/Capabilities.tsx
+++ b/src/components/Capabilities.tsx
@@ -4,39 +4,39 @@ import styles from '@/app/home.module.css'
 const capabilities = [
   {
     key: 'platform.core',
-    title: 'Platform systems people choose to use',
+    title: 'Developer platforms people choose to use',
     description:
-      'Paved roads, self-service workflows, and product thinking for the infrastructure layer.',
-    signal: 'Platform engineering · golden paths · internal products',
+      'Built platform APIs and zero-touch onboarding used by 70+ engineers, with cloud infrastructure experience supporting products serving 8M+ daily users.',
+    signal: 'Platform engineering · Kubernetes · multi-cloud · SRE',
     evidence: 'Inspect the roadmap',
     href: 'https://github.com/mbianchidev/platform-engineering-roadmap'
   },
   {
-    key: 'cloud.runtime',
-    title: 'Cloud-native delivery without the theater',
+    key: 'solutions.interface',
+    title: 'Customer problems translated into shipped systems',
     description:
-      'Production Kubernetes, multi-cloud systems, infrastructure as code, and the judgment to know when not to add another layer.',
-    signal: 'Kubernetes · AWS · Azure · GCP · OpenTofu',
-    evidence: 'Browse open-source work',
+      'Connects technical discovery, architecture, demos, field feedback, and hands-on delivery. Reached 121% quota in the first eight months at GitHub.',
+    signal: 'Solutions engineering · discovery · GTM · product feedback',
+    evidence: 'Review deployment history',
+    href: '/customers'
+  },
+  {
+    key: 'ai.automation',
+    title: 'AI automation with a measurable job',
+    description:
+      'Builds agents and internal tools that remove recurring work without outsourcing judgment—including an assistant that automated 20–25% of Solutions Engineering workload.',
+    signal: 'Python · TypeScript · MCP · agents · developer tooling',
+    evidence: 'Inspect software work',
     href: '/portfolio'
   },
   {
-    key: 'product.interface',
-    title: 'Engineering that behaves like product work',
+    key: 'open.protocol',
+    title: 'Open source and communication that compound',
     description:
-      'Fast prototypes, typed frontends, useful CLIs, and feedback loops that connect technical choices to user outcomes.',
-    signal: 'TypeScript · React · Python · CLI design',
-    evidence: 'See the product surface',
-    href: '/portfolio'
-  },
-  {
-    key: 'story.protocol',
-    title: 'Technical ideas that survive the meeting',
-    description:
-      'Talks, long-form writing, workshops, and community work that make difficult systems easier to understand and adopt.',
-    signal: '22+ talks · writing · DevRel · community',
-    evidence: 'Read the field notes',
-    href: '/blog'
+      'Kubernetes release engineering maintainer, 40+ merged upstream pull requests, 22+ talks, and 300+ learners trained with 95% surveyed CSAT.',
+    signal: 'Kubernetes · OSS strategy · speaking · education',
+    evidence: 'Open community interfaces',
+    href: '/about#community'
   }
 ]
 
@@ -45,9 +45,9 @@ export function Capabilities() {
     <section id="features" className={styles.capabilities} aria-labelledby="capabilities-title">
       <div className={styles.sectionHeader}>
         <p className={styles.sectionCode}>matteo.features()</p>
-        <h2 id="capabilities-title">One hire. Suspiciously broad surface area.</h2>
+        <h2 id="capabilities-title">One hire. Four systems that reinforce each other.</h2>
         <p>
-          The startup framing is a joke. The capabilities are not.
+          The startup framing is a joke. The cross-functional leverage is not.
         </p>
       </div>
 

--- a/src/components/CompatibilityLab.tsx
+++ b/src/components/CompatibilityLab.tsx
@@ -7,63 +7,63 @@ import styles from '@/app/home.module.css'
 const scenarios = [
   {
     id: 'platform',
-    label: 'Platform chaos',
+    label: 'Platform adoption',
     signal: 'MATCH CONFIRMED / HIGH CONFIDENCE',
-    title: 'Compatible with teams that need a paved road, not another portal.',
+    title: 'Build a paved road developers trust enough to take.',
     summary:
-      'Matteo treats the platform as a product: clear users, opinionated defaults, useful feedback loops, and fewer tickets disguised as strategy.',
+      'Matteo treats the platform as a product: clear users, opinionated defaults, useful feedback loops, and infrastructure choices tied to real developer work.',
     proof: [
-      'Created the 111-star Platform Engineering Roadmap',
-      '40+ merged Kubernetes pull requests',
-      'Hands-on multi-cloud and infrastructure-as-code delivery'
+      'Built platform APIs and zero-touch onboarding for 70+ engineers',
+      'Led infrastructure serving products with 8M+ daily users',
+      'Kubernetes release engineering maintainer and production operator'
     ],
     href: 'https://github.com/mbianchidev/platform-engineering-roadmap',
     action: 'Open the platform evidence'
   },
   {
-    id: 'cloud',
-    label: 'Cloud complexity',
-    signal: 'MATCH CONFIRMED / MULTI-CLOUD',
-    title: 'Comfortable where cloud abstractions stop being abstract.',
+    id: 'ai-automation',
+    label: 'Automation backlog',
+    signal: 'MATCH CONFIRMED / HUMAN JUDGMENT RETAINED',
+    title: 'Automate repeated work without automating responsibility.',
     summary:
-      'Architecture, delivery, operations, and cost trade-offs stay connected. The goal is resilient systems, not a diagram with every vendor logo.',
+      'AI is useful when it removes measurable friction. Matteo builds agents, internal assistants, and developer tooling around a defined workflow—not a demo looking for a problem.',
     proof: [
-      'Kubernetes contributor and production operator',
-      'Delivery experience across AWS, Azure, and Google Cloud',
-      'OpenTofu, automation, containers, and CI/CD fluency'
+      'Built an internal assistant that automated 20–25% of Solutions Engineering work',
+      'Ships automation across Python, TypeScript, Rust, and MCP',
+      'Keeps review, observability, and human ownership in the loop'
     ],
     href: '/portfolio',
-    action: 'Review cloud-native work'
+    action: 'Review software and AI work'
   },
   {
-    id: 'developer-experience',
-    label: 'Developer friction',
-    signal: 'MATCH CONFIRMED / PRODUCT MODE',
-    title: 'Treats developer experience as product work with an engineering budget.',
+    id: 'solutions',
+    label: 'Customer-product gap',
+    signal: 'MATCH CONFIRMED / FIELD SIGNAL CONNECTED',
+    title: 'Translate field reality into a product path people can buy and build.',
     summary:
-      'The useful abstraction wins: typed interfaces, focused tooling, fast feedback, and documentation that answers the question before Slack does.',
+      'Technical discovery, architecture, demos, implementation, and product feedback stay connected. The customer gets an honest path forward; the product team gets signal it can use.',
     proof: [
-      'Built Engineering Interviews as a typed developer-learning product',
-      'Ships React, TypeScript, Python, and automation tooling',
-      'Designs for adoption, not just technical completion'
+      'Reached 121% quota in the first eight months at GitHub',
+      'Worked across Sales, Product, Field Marketing, and OSPO',
+      'Combines customer communication with hands-on engineering depth'
     ],
-    href: 'https://github.com/mbianchidev/engineering-interviews',
-    action: 'Inspect the developer product'
+    href: '/customers',
+    action: 'Review customer-facing work'
   },
   {
-    id: 'storytelling',
-    label: 'Invisible expertise',
+    id: 'open-source',
+    label: 'Expertise trapped in heads',
     signal: 'MATCH CONFIRMED / BROADCAST ENABLED',
-    title: 'Turns deep systems work into ideas teams can repeat.',
+    title: 'Make hard-won expertise travel farther than one team.',
     summary:
-      'Technical communication is part of the architecture. Matteo makes complex trade-offs legible to engineers, leaders, and communities without sanding off the nuance.',
+      'Technical communication is part of the architecture. Matteo turns implementation lessons into upstream contributions, strategy, training, talks, and documentation people can reuse.',
     proof: [
-      '22+ talks and workshops delivered',
-      'Long-form cloud-native writing and field guides',
-      'Community leadership across the CNCF ecosystem'
+      '40+ merged Kubernetes pull requests',
+      'Kubernetes release engineering maintainer',
+      '22+ talks and 300+ learners trained with 95% surveyed CSAT'
     ],
     href: '/about#community',
-    action: 'See talks and community work'
+    action: 'See open-source and community work'
   }
 ]
 
@@ -83,8 +83,8 @@ export function CompatibilityLab() {
       <div className={styles.compatibilityIntro}>
         <h2 id="compatibility-title">Run a compatibility check.</h2>
         <p>
-          Select the problem currently haunting your roadmap. The exported page
-          ships with a useful default; JavaScript only changes the diagnosis.
+          Select the problem currently haunting your roadmap. The diagnosis
+          changes; the senior engineer remains suspiciously reusable.
         </p>
       </div>
 

--- a/src/components/CompatibilityLab.tsx
+++ b/src/components/CompatibilityLab.tsx
@@ -29,7 +29,7 @@ const scenarios = [
       'AI is useful when it removes measurable friction. Matteo builds agents, internal assistants, and developer tooling around a defined workflow—not a demo looking for a problem.',
     proof: [
       'Built an internal assistant that automated 20–25% of Solutions Engineering work',
-      'Ships automation across Python, TypeScript, Rust, and MCP',
+      'Built the assistant around real Solutions Engineering workflows and internal tools',
       'Keeps review, observability, and human ownership in the loop'
     ],
     href: '/portfolio',
@@ -43,7 +43,7 @@ const scenarios = [
     summary:
       'Technical discovery, architecture, demos, implementation, and product feedback stay connected. The customer gets an honest path forward; the product team gets signal it can use.',
     proof: [
-      'Reached 121% quota in the first eight months at GitHub',
+      'Won Club FY26 after reaching 180% quota at GitHub',
       'Worked across Sales, Product, Field Marketing, and OSPO',
       'Combines customer communication with hands-on engineering depth'
     ],
@@ -60,7 +60,7 @@ const scenarios = [
     proof: [
       '40+ merged Kubernetes pull requests',
       'Kubernetes release engineering maintainer',
-      '22+ talks and 300+ learners trained with 95% surveyed CSAT'
+      '20+ talks, 500+ learners, and 15+ mentees coached to success (5/5 stars as a mentor)'
     ],
     href: '/about#community',
     action: 'See open-source and community work'
@@ -73,7 +73,7 @@ export function CompatibilityLab() {
 
   useEffect(() => {
     console.info(
-      '%cMatteo diagnostics: source available, ego load within operating limits. Hiring endpoint: https://cal.com/mbianchidev/intro',
+      '%cMatteo diagnostics: source available, ego load within operating limits. Trial endpoint: https://cal.com/mbianchidev/intro',
       'color:#00D9FF;font-weight:700'
     )
   }, [])
@@ -89,7 +89,7 @@ export function CompatibilityLab() {
       </div>
 
       <div className={styles.lab}>
-        <div className={styles.scenarioList} role="group" aria-label="Hiring challenges">
+        <div className={styles.scenarioList} role="group" aria-label="Compatibility scenarios">
           {scenarios.map((scenario) => {
             const isSelected = scenario.id === selected.id
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -53,7 +53,7 @@ export function Footer() {
               LinkedIn
             </a>
             <a href="https://cal.com/mbianchidev/intro" target="_blank" rel="noopener noreferrer">
-              Start interview
+              Start trial
             </a>
             <a href="mailto:info@mb-consulting.dev">Consulting inquiries</a>
           </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,8 +17,8 @@ export function Footer() {
             <BrandLogo />
           </Link>
           <p>
-            Human infrastructure for teams that want the (agenic or not) systems
-            and the story to be equally good.
+            Human infrastructure for teams that need platforms, AI automation,
+            customer outcomes, and clear technical communication to reinforce each other.
           </p>
         </div>
         <div className={styles.footerLinks}>
@@ -53,9 +53,9 @@ export function Footer() {
               LinkedIn
             </a>
             <a href="https://cal.com/mbianchidev/intro" target="_blank" rel="noopener noreferrer">
-              Book a demo
+              Start interview
             </a>
-            <a href="mailto:info@mb-consulting.dev">Contact</a>
+            <a href="mailto:info@mb-consulting.dev">Consulting inquiries</a>
           </div>
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -83,7 +83,7 @@ export function Header() {
               rel="noopener noreferrer"
               className={styles.mobileCta}
             >
-              Start interview
+              Start trial
             </a>
           </li>
         </ul>
@@ -94,7 +94,7 @@ export function Header() {
           rel="noopener noreferrer"
           className={styles.desktopCta}
         >
-          Start interview
+          Start trial
           <span aria-hidden="true">↗</span>
         </a>
       </nav>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -83,7 +83,7 @@ export function Header() {
               rel="noopener noreferrer"
               className={styles.mobileCta}
             >
-              Book a demo
+              Start interview
             </a>
           </li>
         </ul>
@@ -94,7 +94,7 @@ export function Header() {
           rel="noopener noreferrer"
           className={styles.desktopCta}
         >
-          Book a demo
+          Start interview
           <span aria-hidden="true">↗</span>
         </a>
       </nav>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -12,13 +12,12 @@ export function Hero() {
             Matteo v2026.8 is accepting deployments
           </p>
           <h1 id="hero-title" className={styles.heroTitle}>
-            The engineer between product, platform, and people.
+            Platform as a Human
           </h1>
           <p className={styles.heroText}>
-            Senior Engineer — Platforms, Solutions &amp; AI. Matteo turns customer
-            pain into cloud systems, developer platforms, and AI automation people
-            actually adopt—then makes the trade-offs clear to engineers, leaders,
-            and communities.
+            Matteo turns customer pain into cloud systems, developer platforms,
+            and AI automation people actually adopt - then tells the story to
+            engineers, leaders and the open source community.
           </p>
           <div className={styles.heroActions}>
             <a
@@ -27,7 +26,7 @@ export function Hero() {
               rel="noopener noreferrer"
               className={styles.primaryAction}
             >
-              Start a hiring conversation
+              Start trial
               <span aria-hidden="true">↗</span>
             </a>
             <a href="#compatibility" className={styles.secondaryAction}>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -9,15 +9,16 @@ export function Hero() {
         <div className={styles.heroCopy}>
           <p className={styles.releaseBadge}>
             <span aria-hidden="true" />
-            Human infrastructure v2026.7 is ready
+            Matteo v2026.8 is accepting deployments
           </p>
           <h1 id="hero-title" className={styles.heroTitle}>
-            Your next platform hire has an API.
+            The engineer between product, platform, and people.
           </h1>
           <p className={styles.heroText}>
-            Matteo ships cloud-native systems, open-source contributions, and
-            technical stories people actually remember. No seat-based pricing.
-            Mildly opinionated defaults.
+            Senior Engineer — Platforms, Solutions &amp; AI. Matteo turns customer
+            pain into cloud systems, developer platforms, and AI automation people
+            actually adopt—then makes the trade-offs clear to engineers, leaders,
+            and communities.
           </p>
           <div className={styles.heroActions}>
             <a
@@ -26,7 +27,7 @@ export function Hero() {
               rel="noopener noreferrer"
               className={styles.primaryAction}
             >
-              Schedule a live demo
+              Start a hiring conversation
               <span aria-hidden="true">↗</span>
             </a>
             <a href="#compatibility" className={styles.secondaryAction}>
@@ -35,7 +36,7 @@ export function Hero() {
             </a>
           </div>
           <p className={styles.heroFinePrint}>
-            Human-in-the-loop by design. Field-tested since 2015.
+            Full-time is the primary deployment. Select consulting endpoints remain available.
           </p>
         </div>
 
@@ -61,15 +62,15 @@ export function Hero() {
           <dl className={styles.productSpecs}>
             <div className={styles.specRow}>
               <dt>Runtime</dt>
-              <dd>Platform engineering + cloud native</dd>
+              <dd>Senior engineering + customer empathy</dd>
             </div>
             <div className={styles.specRow}>
               <dt>Interfaces</dt>
-              <dd>Code · products · talks · community</dd>
+              <dd>Platforms · solutions · AI · open source</dd>
             </div>
             <div className={styles.specRow}>
               <dt>Known quirk</dt>
-              <dd>May refactor the roadmap before lunch</dd>
+              <dd>May automate the recurring task before lunch</dd>
             </div>
           </dl>
         </aside>

--- a/src/components/KnownIssues.tsx
+++ b/src/components/KnownIssues.tsx
@@ -3,19 +3,19 @@ import styles from '@/app/home.module.css'
 
 const issues = [
   {
-    title: 'Opinionated defaults',
+    title: 'Cross-functional leakage',
     description:
-      'May challenge “that is how we have always done it” without opening a seven-month transformation program.'
+      'May move from customer discovery to architecture to implementation without scheduling a handoff ceremony.'
   },
   {
-    title: 'Open-source reflex',
+    title: 'Automation reflex',
     description:
-      'Frequently turns internal lessons into reusable tools, talks, or documentation. Legal review may experience feelings.'
+      'Repeated work tends to become a script, agent, or internal product. Humans keep the judgment and the reclaimed time.'
   },
   {
-    title: 'Excessive legibility',
+    title: 'Open-source instinct',
     description:
-      'Will explain architecture, trade-offs, and why the team should care. Will also get the work done. People might get upset for this amount of proactivity.'
+      'Will document the system, teach the team, and look for lessons worth contributing upstream.'
   }
 ]
 
@@ -23,7 +23,7 @@ export function KnownIssues() {
   return (
     <section id="contact" className={styles.knownIssues} aria-labelledby="known-issues-title">
       <div className={styles.knownIssuesLead}>
-        <p>Release notes / before procurement asks</p>
+        <p>Release notes / before the interview panel asks</p>
         <h2 id="known-issues-title">Known issues. None are blockers.</h2>
       </div>
       <ul className={styles.issueList}>
@@ -41,14 +41,14 @@ export function KnownIssues() {
           rel="noopener noreferrer"
           className={styles.darkAction}
         >
-          buy Matteo
+          Start the interview loop
           <span aria-hidden="true">↗</span>
         </a>
         <Link href="/roadmap" className={styles.inkAction}>
           See changelog
         </Link>
       </div>
-      <p className={styles.responseSla}>Response SLA: usually faster than procurement.</p>
+      <p className={styles.responseSla}>Primary deployment: full-time. Consulting capacity: selective.</p>
     </section>
   )
 }

--- a/src/components/KnownIssues.tsx
+++ b/src/components/KnownIssues.tsx
@@ -41,7 +41,7 @@ export function KnownIssues() {
           rel="noopener noreferrer"
           className={styles.darkAction}
         >
-          Start the interview loop
+          Start trial
           <span aria-hidden="true">↗</span>
         </a>
         <Link href="/roadmap" className={styles.inkAction}>

--- a/src/components/ProofLedger.tsx
+++ b/src/components/ProofLedger.tsx
@@ -4,7 +4,7 @@ import styles from '@/app/home.module.css'
 
 const ownedProjects = projectsData.projects
   .filter((project) => project.contribution.startsWith('Creator'))
-  .slice(0, 3)
+  .slice(0, 2)
 
 const [featuredProject, ...supportingProjects] = ownedProjects
 
@@ -14,7 +14,7 @@ export function ProofLedger() {
       <div className={styles.proofHeader}>
         <div>
           <h2 id="proof-title">Do not trust the landing page.</h2>
-          <p>Open the source. The receipts are significantly less fictional.</p>
+          <p>Open the source. The claims become significantly less fictional.</p>
         </div>
         <Link href="/portfolio" className={styles.textLink}>
           Full OSS portfolio

--- a/src/components/Toolchain.tsx
+++ b/src/components/Toolchain.tsx
@@ -3,7 +3,8 @@ import styles from '@/app/home.module.css'
 const tools = [
   { name: 'Kubernetes', note: 'orchestration' },
   { name: 'Go', note: 'systems' },
-  { name: 'Python', note: 'automation' },
+  { name: 'Python', note: 'AI + automation' },
+  { name: 'Rust', note: 'systems tooling' },
   { name: 'TypeScript', note: 'products' },
   { name: 'React', note: 'interfaces' },
   { name: 'AWS', note: 'cloud' },
@@ -12,17 +13,18 @@ const tools = [
   { name: 'GitHub', note: 'delivery' },
   { name: 'Docker', note: 'containers' },
   { name: 'OpenTofu', note: 'infrastructure' },
-  { name: 'MCP', note: 'AI systems' }
+  { name: 'AI agents', note: 'workflow leverage' },
+  { name: 'MCP', note: 'tool integration' }
 ]
 
 export function Toolchain() {
   return (
     <section id="integrations" className={styles.toolchain} aria-labelledby="toolchain-title">
       <div className={styles.toolchainLead}>
-        <h2 id="toolchain-title">Native integrations. Emotionally stable dependencies.</h2>
+        <h2 id="toolchain-title">Native integrations. Human judgment included.</h2>
         <p>
-          Fits into the stack you already run. Will still ask why there are three
-          CI systems.
+          Comfortable across cloud, code, and AI tooling—and opinionated enough
+          not to force every problem through the same stack.
         </p>
       </div>
       <ul className={styles.toolList}>

--- a/src/components/TrustedBy.tsx
+++ b/src/components/TrustedBy.tsx
@@ -59,8 +59,9 @@ export function TrustedBy() {
       <div className={styles.lovedByHeader}>
         <h2 id="loved-by-title">Loved and trusted by people at</h2>
         <p>
-          The legally safe version: excellent humans from these places have crossed
-          paths with Matteo. Corporate endorsement sold separately.
+          The legally safe version: Matteo has shipped, collaborated, taught, or
+          built community with excellent humans from these places. Corporate
+          endorsement remains an add-on.
         </p>
       </div>
       <div className={styles.logoRunway}>

--- a/src/data/customers.json
+++ b/src/data/customers.json
@@ -35,7 +35,7 @@
               "text": "20+ CNCF events and meetups"
             },
             {
-              "text": "22 conference talks"
+              "text": "20+ conference talks"
             },
             {
               "text": "Published 10+ blogs"

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -2,7 +2,7 @@
   "projects": [
     {
       "name": "Platform Engineering Roadmap",
-      "description": "An opinionated platform engineering roadmap - in the form of an interactive website to help engineers navigate the platform engineering landscape",
+      "description": "An opinionated, interactive roadmap that helps engineers navigate the platform engineering landscape",
       "url": "https://github.com/mbianchidev/platform-engineering-roadmap",
       "stars": "111",
       "techStack": [
@@ -13,8 +13,20 @@
       "contribution": "Creator and maintainer"
     },
     {
+      "name": "Sendbox",
+      "description": "An all-in-one sandbox for agentic CLI development, built to isolate AI agents with container-based environments",
+      "url": "https://github.com/mbianchidev/sendbox",
+      "stars": "1",
+      "techStack": [
+        "Rust",
+        "AI Agents",
+        "Containers"
+      ],
+      "contribution": "Creator and maintainer"
+    },
+    {
       "name": "Engineering Interviews",
-      "description": "Questions to prepare for engineering interviews and coding challenges solutions to help developers ace their technical interviews",
+      "description": "A learning product with interview questions and coding challenge solutions for engineers preparing for technical interviews",
       "url": "https://github.com/mbianchidev/engineering-interviews",
       "stars": "9",
       "techStack": [

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -59,12 +59,12 @@ test.describe('Static route experience', () => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await page.locator('html[data-hydrated="true"]').waitFor();
 
-    const developerExperience = page.getByRole('button', { name: /Developer friction/ });
-    await developerExperience.click();
+    const automationBacklog = page.getByRole('button', { name: /Automation backlog/ });
+    await automationBacklog.click();
 
-    await expect(developerExperience).toHaveAttribute('aria-pressed', 'true');
+    await expect(automationBacklog).toHaveAttribute('aria-pressed', 'true');
     await expect(page.locator('#compatibility-result')).toContainText(
-      'Treats developer experience as product work'
+      'Automate repeated work without automating responsibility.'
     );
   });
 
@@ -144,39 +144,39 @@ test.describe('Static route experience', () => {
   test('uses the requested homepage copy and balanced proof layout', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('link', { name: 'buy Matteo' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Start the interview loop' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'See changelog' })).toHaveAttribute(
       'href',
       '/roadmap/'
     );
     await expect(
       page.getByText(
-        'Human infrastructure for teams that want the (agenic or not) systems and the story to be equally good.'
+        'Human infrastructure for teams that need platforms, AI automation, customer outcomes, and clear technical communication to reinforce each other.'
       )
     ).toBeVisible();
     await expect(
       page.getByText(
-        'Will explain architecture, trade-offs, and why the team should care. Will also get the work done. People might get upset for this amount of proactivity.'
+        'Repeated work tends to become a script, agent, or internal product. Humans keep the judgment and the reclaimed time.'
       )
     ).toBeVisible();
 
     const featured = page
       .getByRole('heading', { name: 'Platform Engineering Roadmap' })
       .locator('xpath=ancestor::article');
-    const engineeringInterviews = page
-      .getByRole('heading', { name: 'Engineering Interviews' })
+    const sendbox = page
+      .getByRole('heading', { name: 'Sendbox' })
       .locator('xpath=ancestor::article');
-    const [featuredBox, interviewsBox] = await Promise.all([
+    const [featuredBox, sendboxBox] = await Promise.all([
       featured.boundingBox(),
-      engineeringInterviews.boundingBox(),
+      sendbox.boundingBox(),
     ]);
 
     expect(featuredBox).not.toBeNull();
-    expect(interviewsBox).not.toBeNull();
-    expect(Math.abs(featuredBox!.height - interviewsBox!.height)).toBeLessThan(2);
+    expect(sendboxBox).not.toBeNull();
+    expect(Math.abs(featuredBox!.height - sendboxBox!.height)).toBeLessThan(2);
 
     const integrations = page
-      .getByRole('heading', { name: 'Native integrations. Emotionally stable dependencies.' })
+      .getByRole('heading', { name: 'Native integrations. Human judgment included.' })
       .locator('xpath=ancestor::section');
     const integrationsColors = await integrations.evaluate((section) => {
       const computed = getComputedStyle(section);

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -55,7 +55,7 @@ test.describe('Static route experience', () => {
     }
   });
 
-  test('updates the hiring compatibility result', async ({ page }) => {
+  test('updates the compatibility result', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await page.locator('html[data-hydrated="true"]').waitFor();
 
@@ -144,7 +144,13 @@ test.describe('Static route experience', () => {
   test('uses the requested homepage copy and balanced proof layout', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('link', { name: 'Start the interview loop' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Platform as a Human' })).toBeVisible();
+    await expect(
+      page.getByText(
+        'Matteo turns customer pain into cloud systems, developer platforms, and AI automation people actually adopt - then tells the story to engineers, leaders and the open source community.'
+      )
+    ).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Start trial' }).first()).toBeVisible();
     await expect(page.getByRole('link', { name: 'See changelog' })).toHaveAttribute(
       'href',
       '/roadmap/'
@@ -190,6 +196,56 @@ test.describe('Static route experience', () => {
       background: 'rgb(0, 217, 255)',
       color: 'rgb(10, 10, 11)',
     });
+  });
+
+  test('keeps benchmark metrics and pricing headers from overlapping', async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const benchmarks = page
+      .getByRole('heading', { name: 'Field report, not vanity dashboard.' })
+      .locator('xpath=ancestor::section');
+    const metricRows = benchmarks.locator('dl > div');
+    await expect(metricRows).toHaveCount(3);
+
+    for (let index = 0; index < 3; index += 1) {
+      const row = metricRows.nth(index);
+      const [valueBox, copyBox] = await Promise.all([
+        row.locator('dt').boundingBox(),
+        row.locator('dd').boundingBox(),
+      ]);
+
+      expect(valueBox).not.toBeNull();
+      expect(copyBox).not.toBeNull();
+      expect(valueBox!.x + valueBox!.width).toBeLessThan(copyBox!.x);
+    }
+
+    const primaryMetricLines = await benchmarks.getByText('20–25%', { exact: true }).evaluate(
+      (element) => {
+        const range = document.createRange();
+        range.selectNodeContents(element);
+        return range.getClientRects().length;
+      }
+    );
+    expect(primaryMetricLines).toBe(1);
+
+    await page.goto('/pricing', { waitUntil: 'domcontentloaded' });
+
+    for (const planName of ['Advisory', 'Delivery & enablement', 'Full-time']) {
+      const plan = page
+        .getByRole('heading', { name: planName, exact: true })
+        .locator('xpath=ancestor::article');
+      const [headingBox, priceBox, hasOverflow] = await Promise.all([
+        plan.getByRole('heading', { name: planName, exact: true }).boundingBox(),
+        plan.locator('strong').first().boundingBox(),
+        plan.evaluate((article) => article.scrollWidth > article.clientWidth + 1),
+      ]);
+
+      expect(headingBox).not.toBeNull();
+      expect(priceBox).not.toBeNull();
+      expect(headingBox!.y + headingBox!.height).toBeLessThan(priceBox!.y);
+      expect(hasOverflow).toBe(false);
+    }
   });
 
   test('navigates to Privacy and Terms from the footer', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Position Matteo as a Senior Engineer across platforms, solutions, software, and AI
- Replace generic claims with measurable evidence from the public curriculum
- Make full-time hiring the primary conversion path while keeping selective Kubernetes, open-source, education, and speaking consulting
- Align homepage, About, Careers, Pricing, Portfolio, metadata, README, and browser assertions
- Add Sendbox as current public AI-agent tooling evidence

## Validation
- `npm ci` (0 vulnerabilities)
- `npm run lint`
- `npm run build`
- Playwright: 28 passed
- Static export smoke-tested across homepage, Careers, Pricing, and Portfolio