### PR TITLE
[fix] Align pricing cards

### DIFF
--- a/src/app/inner.module.css
+++ b/src/app/inner.module.css
@@ -1304,12 +1304,13 @@
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 18px;
-    align-items: start;
+    align-items: stretch;
 }
 
 .pricingPlan {
     display: flex;
     flex-direction: column;
+    height: 100%;
     min-width: 0;
     min-height: 560px;
     padding: 28px;
@@ -1325,6 +1326,7 @@
 }
 
 .planHeader {
+    position: relative;
     display: grid;
     gap: 18px;
     align-content: start;
@@ -1334,8 +1336,15 @@
     min-width: 0;
 }
 
+.recommendedPlan .planHeader > div:first-child {
+    padding-right: 88px;
+}
+
 .planHeader p {
-    margin: 0 0 8px;
+    position: absolute;
+    top: 0.35rem;
+    right: 0;
+    margin: 0;
     font-size: 0.74rem;
     font-weight: 900;
 }
@@ -1373,7 +1382,7 @@
 }
 
 .pricingPlan > p {
-    min-height: 104px;
+    min-height: calc(1.65em * 4);
     margin: 26px 0 22px;
     color: color-mix(in srgb, var(--bg-primary) 76%, transparent);
     line-height: 1.65;

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -34,7 +34,7 @@ const pricingPlans: PricingPlan[] = [
   },
   {
     id: 'delivery',
-    name: 'Delivery & enablement',
+    name: 'Delivery',
     description: 'Hands-on Kubernetes work, technical education, and adoption support for teams that need the recommendation implemented and understood.',
     price: '€150',
     hourlyRate: 150,

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -198,7 +198,7 @@ test.describe('Static route experience', () => {
     });
   });
 
-  test('keeps benchmark metrics and pricing headers from overlapping', async ({ page }) => {
+  test('keeps benchmark metrics separated and pricing cards aligned', async ({ page }) => {
     await page.setViewportSize({ width: 1600, height: 1000 });
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
@@ -231,20 +231,62 @@ test.describe('Static route experience', () => {
 
     await page.goto('/pricing', { waitUntil: 'domcontentloaded' });
 
-    for (const planName of ['Advisory', 'Delivery & enablement', 'Full-time']) {
+    const pricingRows: Array<{
+      articleTop: number;
+      articleBottom: number;
+      headingTop: number;
+      priceTop: number;
+      descriptionTop: number;
+      toggleTop: number;
+      actionTop: number;
+    }> = [];
+
+    for (const planName of ['Advisory', 'Delivery', 'Full-time']) {
       const plan = page
         .getByRole('heading', { name: planName, exact: true })
         .locator('xpath=ancestor::article');
-      const [headingBox, priceBox, hasOverflow] = await Promise.all([
-        plan.getByRole('heading', { name: planName, exact: true }).boundingBox(),
-        plan.locator('strong').first().boundingBox(),
-        plan.evaluate((article) => article.scrollWidth > article.clientWidth + 1),
-      ]);
+      const [articleBox, headingBox, priceBox, descriptionBox, toggleBox, actionBox, hasOverflow] =
+        await Promise.all([
+          plan.boundingBox(),
+          plan.getByRole('heading', { name: planName, exact: true }).boundingBox(),
+          plan.locator('strong').first().boundingBox(),
+          plan.locator(':scope > p').boundingBox(),
+          plan.getByRole('button').boundingBox(),
+          plan.locator(':scope > a').boundingBox(),
+          plan.evaluate((article) => article.scrollWidth > article.clientWidth + 1),
+        ]);
 
+      expect(articleBox).not.toBeNull();
       expect(headingBox).not.toBeNull();
       expect(priceBox).not.toBeNull();
+      expect(descriptionBox).not.toBeNull();
+      expect(toggleBox).not.toBeNull();
+      expect(actionBox).not.toBeNull();
       expect(headingBox!.y + headingBox!.height).toBeLessThan(priceBox!.y);
       expect(hasOverflow).toBe(false);
+
+      pricingRows.push({
+        articleTop: articleBox!.y,
+        articleBottom: articleBox!.y + articleBox!.height,
+        headingTop: headingBox!.y,
+        priceTop: priceBox!.y,
+        descriptionTop: descriptionBox!.y,
+        toggleTop: toggleBox!.y,
+        actionTop: actionBox!.y,
+      });
+    }
+
+    for (const row of [
+      'articleTop',
+      'articleBottom',
+      'headingTop',
+      'priceTop',
+      'descriptionTop',
+      'toggleTop',
+      'actionTop',
+    ] as const) {
+      const positions = pricingRows.map((plan) => plan[row]);
+      expect(Math.max(...positions) - Math.min(...positions)).toBeLessThanOrEqual(1);
     }
   });
 


### PR DESCRIPTION
## Summary
- rename the Delivery & enablement tier to Delivery
- align pricing card headings, prices, descriptions, controls, actions, and card edges
- add a Playwright regression assertion for the shared rows

## Validation
- npm run lint
- npm run build
- targeted Playwright pricing layout test