### PR TITLE
[feature] Add configurable links page

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,25 @@ src/
 └── lib/                # Utility functions
 ```
 
+## 🔗 Configuring `/links`
+
+Profile copy and link destinations live in `src/data/links.ts`. To add a link,
+duplicate an item in the `links` array and update its values:
+
+```ts
+{
+  service: 'Service name',
+  title: 'Visible link title',
+  description: 'One-line description',
+  href: 'https://example.com',
+  icon: 'github',
+}
+```
+
+The built-in icon values are `mentor`, `youtube`, and `github`. To add another
+icon, extend `PublicLinkIcon` in `src/data/links.ts` and add its SVG case to
+`LinkIcon` in `src/app/links/page.tsx`.
+
 ## 🔧 Available Scripts
 
 - `npm run dev` - Clear stale `.next` artifacts and start the development server

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project is a satirical product launch for Matteo Bianchi: a personal portfo
 - Homepage runway logos are bundled locally and loaded eagerly so marquee motion never reveals unloaded placeholders
 - An open-source proof ledger sourced from `src/data/projects.json`
 - A complete route system for field notes, changelog, portfolio, deployment history, pricing, legal, and support pages
+- A configurable `/links` endpoint manifest sourced from `src/data/links.ts`
 - Original high-resolution organisation logos with a clean KubeLab monogram fallback throughout Customers
 - Verifiable contribution, speaking, and project benchmarks
 - Satirical release notes and direct trial calls to action
@@ -122,6 +123,7 @@ src/
 │   ├── page.tsx         # Homepage
 │   ├── home.module.css  # Homepage visual system
 │   ├── inner.module.css # Shared inner-page visual system
+│   ├── links/           # Configurable public link manifest
 │   ├── about/           # About page
 │   ├── careers/         # Careers page
 │   ├── customers/       # Customers page
@@ -154,7 +156,8 @@ src/
 ├── types/               # TypeScript type definitions
 │   └── index.ts
 ├── data/               # JSON data files
-│   └── customers.json
+│   ├── customers.json
+│   └── links.ts         # Profile copy and public link configuration
 └── lib/                # Utility functions
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5016,9 +5016,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src/app/links/links.module.css
+++ b/src/app/links/links.module.css
@@ -1,0 +1,310 @@
+.page {
+    position: relative;
+    min-height: calc(100vh - 72px);
+    color: var(--text-primary);
+    background: var(--bg-primary);
+    isolation: isolate;
+    overflow: hidden;
+}
+
+.stage {
+    padding: clamp(54px, 8vw, 104px) clamp(18px, 4vw, 48px) clamp(72px, 9vw, 120px);
+}
+
+.shell {
+    width: min(100%, 760px);
+    margin: 0 auto;
+}
+
+.profile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.avatarFrame {
+    position: relative;
+    width: 112px;
+    height: 112px;
+    padding: 5px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 50%;
+}
+
+.avatar {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: 57% 32%;
+    border-radius: 50%;
+}
+
+.onlineIndicator {
+    position: absolute;
+    right: 2px;
+    bottom: 8px;
+    width: 18px;
+    height: 18px;
+    background: var(--accent-color);
+    border: 4px solid var(--bg-primary);
+    border-radius: 50%;
+}
+
+.availability {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin: 10px 0 0;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 700;
+}
+
+.availability > span {
+    width: 7px;
+    height: 7px;
+    background: var(--accent-color);
+    border-radius: 50%;
+}
+
+.profile h1 {
+    margin: 22px 0 0;
+    color: var(--text-primary);
+    font-family: var(--font-display);
+    font-size: clamp(3.4rem, 7.6vw, 6rem);
+    font-weight: 400;
+    line-height: 0.98;
+    letter-spacing: -0.035em;
+    text-wrap: balance;
+}
+
+.tagline {
+    margin: 13px 0 0;
+    color: var(--primary-color);
+    font-size: 1rem;
+    font-weight: 800;
+}
+
+.description {
+    max-width: 56ch;
+    margin: 16px 0 0;
+    color: var(--text-secondary);
+    font-size: 1rem;
+    line-height: 1.65;
+    text-wrap: pretty;
+}
+
+.manifestHeader {
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    margin-top: clamp(42px, 7vw, 64px);
+    padding: 13px 2px;
+    color: var(--text-secondary);
+    border-top: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color);
+    font-size: 0.8rem;
+    font-weight: 700;
+}
+
+.manifestHeader span:last-child {
+    color: var(--accent-color);
+}
+
+.linkList {
+    display: grid;
+    gap: 14px;
+    margin: 18px 0 0;
+}
+
+.linkRow {
+    display: grid;
+    grid-template-columns: 58px minmax(0, 1fr) 42px;
+    gap: 20px;
+    align-items: center;
+    min-height: 112px;
+    padding: 18px 20px;
+    color: var(--text-primary);
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    transition:
+        transform 180ms cubic-bezier(0.22, 1, 0.36, 1),
+        background-color 180ms cubic-bezier(0.22, 1, 0.36, 1),
+        border-color 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.linkRow:hover {
+    color: var(--text-primary);
+    background: var(--bg-elevated);
+    border-color: var(--primary-color);
+    transform: translateY(-3px);
+}
+
+.icon,
+.arrow {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--primary-color);
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    transition:
+        color 180ms cubic-bezier(0.22, 1, 0.36, 1),
+        background-color 180ms cubic-bezier(0.22, 1, 0.36, 1),
+        border-color 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.icon {
+    width: 58px;
+    height: 58px;
+}
+
+.icon svg {
+    width: 27px;
+    height: 27px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.7;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+
+.linkRow:hover .icon,
+.linkRow:hover .arrow {
+    color: var(--bg-primary);
+    background: var(--primary-color);
+    border-color: var(--primary-color);
+}
+
+.linkCopy {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.service {
+    color: var(--primary-color);
+    font-size: 0.8rem;
+    font-weight: 800;
+}
+
+.linkCopy strong {
+    margin-top: 3px;
+    font-size: 1rem;
+    line-height: 1.25;
+}
+
+.linkCopy > span:last-child {
+    margin-top: 5px;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.45;
+    text-wrap: pretty;
+}
+
+.arrow {
+    width: 42px;
+    height: 42px;
+    font-size: 1rem;
+    font-weight: 800;
+}
+
+.localFooter {
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    align-items: center;
+    margin-top: 22px;
+    padding: 0 2px;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+}
+
+.localFooter a {
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+    min-height: 44px;
+    color: var(--text-secondary);
+    font-weight: 800;
+    transition: color 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.localFooter a:hover {
+    color: var(--primary-color);
+}
+
+.page a:focus-visible {
+    outline: 3px solid var(--accent-color);
+    outline-offset: 4px;
+}
+
+@media (max-width: 560px) {
+    .stage {
+        padding-top: 44px;
+    }
+
+    .avatarFrame {
+        width: 100px;
+        height: 100px;
+    }
+
+    .profile h1 {
+        font-size: 2.15rem;
+    }
+
+    .manifestHeader {
+        gap: 16px;
+    }
+
+    .linkRow {
+        grid-template-columns: 50px minmax(0, 1fr) 36px;
+        gap: 14px;
+        min-height: 104px;
+        padding: 16px;
+    }
+
+    .icon {
+        width: 50px;
+        height: 50px;
+    }
+
+    .arrow {
+        width: 36px;
+        height: 36px;
+    }
+
+    .localFooter {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 10px;
+    }
+}
+
+@media (max-width: 390px) {
+    .linkRow {
+        grid-template-columns: 46px minmax(0, 1fr);
+    }
+
+    .icon {
+        width: 46px;
+        height: 46px;
+    }
+
+    .arrow {
+        display: none;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .linkRow,
+    .icon,
+    .arrow,
+    .localFooter a {
+        transition: none;
+    }
+}

--- a/src/app/links/links.module.css
+++ b/src/app/links/links.module.css
@@ -80,13 +80,6 @@
     text-wrap: balance;
 }
 
-.tagline {
-    margin: 13px 0 0;
-    color: var(--primary-color);
-    font-size: 1rem;
-    font-weight: 800;
-}
-
 .description {
     max-width: 56ch;
     margin: 16px 0 0;
@@ -213,31 +206,6 @@
     font-weight: 800;
 }
 
-.localFooter {
-    display: flex;
-    justify-content: space-between;
-    gap: 24px;
-    align-items: center;
-    margin-top: 22px;
-    padding: 0 2px;
-    color: var(--text-secondary);
-    font-size: 0.8rem;
-}
-
-.localFooter a {
-    display: inline-flex;
-    gap: 8px;
-    align-items: center;
-    min-height: 44px;
-    color: var(--text-secondary);
-    font-weight: 800;
-    transition: color 180ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.localFooter a:hover {
-    color: var(--primary-color);
-}
-
 .page a:focus-visible {
     outline: 3px solid var(--accent-color);
     outline-offset: 4px;
@@ -278,11 +246,6 @@
         height: 36px;
     }
 
-    .localFooter {
-        align-items: flex-start;
-        flex-direction: column;
-        gap: 10px;
-    }
 }
 
 @media (max-width: 390px) {
@@ -303,8 +266,7 @@
 @media (prefers-reduced-motion: reduce) {
     .linkRow,
     .icon,
-    .arrow,
-    .localFooter a {
+    .arrow {
         transition: none;
     }
 }

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from 'next'
+import Image from 'next/image'
+import Link from 'next/link'
+import matteoPortrait from '@/assets/matteo-kcd-denmark.jpg'
+import { linksPageConfig, type PublicLinkIcon } from '@/data/links'
+import { createPageMetadata } from '@/lib/siteMetadata'
+import styles from './links.module.css'
+
+export const metadata: Metadata = createPageMetadata({
+  title: 'Links — Matteo',
+  description:
+    'Mentoring, videos, and open-source work from Matteo Bianchi in one public endpoint manifest.',
+  path: '/links/',
+})
+
+function LinkIcon({ icon }: { icon: PublicLinkIcon }) {
+  if (icon === 'mentor') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M8.5 11.25a3.25 3.25 0 1 0 0-6.5 3.25 3.25 0 0 0 0 6.5Z" />
+        <path d="M3.75 19.25v-1.5a4.75 4.75 0 0 1 9.5 0v1.5" />
+        <path d="M15.5 7.25h4.75v4.5H18l-2.5 2v-6.5Z" />
+      </svg>
+    )
+  }
+
+  if (icon === 'youtube') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <rect x="2.75" y="5.25" width="18.5" height="13.5" rx="4" />
+        <path d="m10 9 5 3-5 3V9Z" fill="currentColor" stroke="none" />
+      </svg>
+    )
+  }
+
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        d="M12 2.75a9.5 9.5 0 0 0-3 18.51c.48.09.65-.2.65-.46v-1.84c-2.67.58-3.23-1.13-3.23-1.13-.44-1.11-1.07-1.4-1.07-1.4-.87-.6.07-.59.07-.59.96.07 1.47.99 1.47.99.86 1.46 2.25 1.04 2.8.8.09-.62.34-1.04.61-1.28-2.13-.24-4.37-1.07-4.37-4.74 0-1.05.37-1.9.99-2.58-.1-.24-.43-1.22.09-2.54 0 0 .8-.26 2.64.98A9.15 9.15 0 0 1 12 7.15c.82 0 1.63.11 2.4.32 1.82-1.24 2.63-.98 2.63-.98.52 1.32.19 2.3.09 2.54.61.68.98 1.53.98 2.58 0 3.68-2.24 4.5-4.38 4.74.35.3.65.88.65 1.77v2.68c0 .26.17.56.66.46A9.5 9.5 0 0 0 12 2.75Z"
+        fill="currentColor"
+        stroke="none"
+      />
+    </svg>
+  )
+}
+
+export default function LinksPage() {
+  return (
+    <div className={styles.page}>
+      <section className={styles.stage} aria-label="Public links">
+        <div className={styles.shell}>
+          <div className={styles.profile}>
+            <div className={styles.avatarFrame}>
+              <Image
+                src={matteoPortrait}
+                alt="Matteo Bianchi speaking at KCD Denmark"
+                className={styles.avatar}
+                priority
+                sizes="112px"
+              />
+              <span className={styles.onlineIndicator} aria-hidden="true" />
+            </div>
+
+            <h1>{linksPageConfig.handle}</h1>
+            <p className={styles.tagline}>{linksPageConfig.tagline}</p>
+            <p className={styles.availability}>
+              <span aria-hidden="true" />
+              Public interface online
+            </p>
+            <p className={styles.description}>{linksPageConfig.description}</p>
+          </div>
+
+          <div className={styles.manifestHeader}>
+            <span>Public endpoint manifest</span>
+            <span>{linksPageConfig.links.length} routes online</span>
+          </div>
+
+          <ul className={styles.linkList}>
+            {linksPageConfig.links.map((link) => (
+              <li key={link.href}>
+                <a
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.linkRow}
+                >
+                  <span className={styles.icon}>
+                    <LinkIcon icon={link.icon} />
+                  </span>
+                  <span className={styles.linkCopy}>
+                    <span className={styles.service}>{link.service}</span>
+                    <strong>{link.title}</strong>
+                    <span>{link.description}</span>
+                  </span>
+                  <span className={styles.arrow} aria-hidden="true">
+                    ↗
+                  </span>
+                </a>
+              </li>
+            ))}
+          </ul>
+
+          <div className={styles.localFooter}>
+            <p>Three routes. Zero algorithmic roulette.</p>
+            <Link href="/">
+              Open full product
+              <span aria-hidden="true">→</span>
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 import Image from 'next/image'
-import Link from 'next/link'
 import matteoPortrait from '@/assets/matteo-kcd-denmark.jpg'
 import { linksPageConfig, type PublicLinkIcon } from '@/data/links'
 import { createPageMetadata } from '@/lib/siteMetadata'
@@ -60,9 +59,7 @@ export default function LinksPage() {
               />
               <span className={styles.onlineIndicator} aria-hidden="true" />
             </div>
-
             <h1>{linksPageConfig.handle}</h1>
-            <p className={styles.tagline}>{linksPageConfig.tagline}</p>
             <p className={styles.availability}>
               <span aria-hidden="true" />
               Public interface online
@@ -99,14 +96,6 @@ export default function LinksPage() {
               </li>
             ))}
           </ul>
-
-          <div className={styles.localFooter}>
-            <p>Three routes. Zero algorithmic roulette.</p>
-            <Link href="/">
-              Open full product
-              <span aria-hidden="true">→</span>
-            </Link>
-          </div>
         </div>
       </section>
     </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -39,6 +39,7 @@ export function Footer() {
           <div className={styles.footerColumn} role="navigation" aria-label="Resources">
             <h3>Resources</h3>
             <Link href="/blog">Blog</Link>
+            <Link href="/links">Links</Link>
             <Link href="/documentation">Documentation</Link>
             <Link href="/press">Press</Link>
             <Link href="/support">Support</Link>

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -1,0 +1,46 @@
+export type PublicLinkIcon = 'mentor' | 'youtube' | 'github'
+
+export interface PublicLink {
+  service: string
+  title: string
+  description: string
+  href: string
+  icon: PublicLinkIcon
+}
+
+interface LinksPageConfig {
+  handle: string
+  tagline: string
+  description: string
+  links: PublicLink[]
+}
+
+export const linksPageConfig: LinksPageConfig = {
+  handle: '@mbianchidev',
+  tagline: 'Code = Liability',
+  description:
+    'Senior engineer, open-source contributor, and professional translator between humans and distributed systems.',
+  links: [
+    {
+      service: 'MentorCruise',
+      title: 'You getting mentored (by me)',
+      description: 'One-to-one engineering mentorship for the next hard problem.',
+      href: 'https://mentorcruise.com/mentor/matteobianchi',
+      icon: 'mentor',
+    },
+    {
+      service: 'YouTube',
+      title: 'Me yapping about stuff',
+      description: 'Cloud native, open source, platforms, and opinions with diagrams.',
+      href: 'https://youtube.com/mbianchidev',
+      icon: 'youtube',
+    },
+    {
+      service: 'GitHub',
+      title: 'Spaghetti code, publicly auditable',
+      description: 'Repositories, upstream contributions, experiments, and receipts.',
+      href: 'https://github.com/mbianchidev',
+      icon: 'github',
+    },
+  ],
+}

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -10,14 +10,12 @@ export interface PublicLink {
 
 interface LinksPageConfig {
   handle: string
-  tagline: string
   description: string
   links: PublicLink[]
 }
 
 export const linksPageConfig: LinksPageConfig = {
   handle: '@mbianchidev',
-  tagline: 'Code = Liability',
   description:
     'Senior engineer, open-source contributor, and professional translator between humans and distributed systems.',
   links: [

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -67,6 +67,7 @@ test.describe('Static route experience', () => {
 
     const publicLinks = page.getByRole('region', { name: 'Public links' });
     await expect(page.getByRole('heading', { name: '@mbianchidev' })).toBeVisible();
+    await expect(publicLinks.getByRole('link')).toHaveCount(3);
 
     const expectedLinks = [
       {

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 
 const pages = [
   { name: 'homepage', path: '/', title: 'Matteo — The Human Platform' },
+  { name: 'links', path: '/links', title: 'Links — Matteo' },
   { name: 'about', path: '/about', title: 'Product Internals — Matteo' },
   { name: 'blog', path: '/blog', title: 'Field Notes — Matteo' },
   {
@@ -49,6 +50,9 @@ test.describe('Static route experience', () => {
     await page.goto('/about', { waitUntil: 'domcontentloaded' });
     await expect(canonical).toHaveAttribute('href', 'https://mbianchi.dev/about/');
 
+    await page.goto('/links', { waitUntil: 'domcontentloaded' });
+    await expect(canonical).toHaveAttribute('href', 'https://mbianchi.dev/links/');
+
     await page.goto('/blog/yet-another-monumentally-long-year-in-review-2025', {
       waitUntil: 'domcontentloaded',
     });
@@ -56,6 +60,34 @@ test.describe('Static route experience', () => {
       'href',
       'https://mbianchi.dev/blog/yet-another-monumentally-long-year-in-review-2025/'
     );
+  });
+
+  test('publishes the configurable public link manifest', async ({ page }) => {
+    await page.goto('/links', { waitUntil: 'domcontentloaded' });
+
+    const publicLinks = page.getByRole('region', { name: 'Public links' });
+    await expect(page.getByRole('heading', { name: '@mbianchidev' })).toBeVisible();
+
+    const expectedLinks = [
+      {
+        service: 'MentorCruise',
+        href: 'https://mentorcruise.com/mentor/matteobianchi',
+      },
+      {
+        service: 'YouTube',
+        href: 'https://youtube.com/mbianchidev',
+      },
+      {
+        service: 'GitHub',
+        href: 'https://github.com/mbianchidev',
+      },
+    ];
+
+    for (const expectedLink of expectedLinks) {
+      const link = publicLinks.getByRole('link', { name: new RegExp(expectedLink.service) });
+      await expect(link).toHaveAttribute('href', expectedLink.href);
+      await expect(link).toHaveAttribute('target', '_blank');
+    }
   });
 
   test('publishes the complete English blog archive', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a responsive `/links` endpoint manifest matching the existing Matteo visual system
- keep profile copy and destinations configurable in `src/data/links.ts`
- add route metadata, footer discovery, documentation, and Playwright coverage
- update the transitive `nanoid` lock entry to resolve the install audit finding

## Validation
- `npm run lint`
- `npm run build`
- `npx playwright test tests/pages.spec.ts --grep "publishes canonical URLs|publishes the configurable public link manifest"`
- desktop and mobile Playwright browser checks
- `npm audit --audit-level=high`
