### PR TITLE
[feature] build an actual blog front page

### DIFF
--- a/src/app/blog/blog.module.css
+++ b/src/app/blog/blog.module.css
@@ -1,0 +1,531 @@
+.blogPage {
+    min-height: 100vh;
+    color: var(--text-primary);
+    background: var(--bg-primary);
+    overflow-wrap: anywhere;
+}
+
+.blogPage :where(h1, h2, h3, p, dl, dd) {
+    margin: 0;
+}
+
+.blogPage h2::after {
+    display: none;
+}
+
+.blogPage a:focus-visible {
+    outline: 3px solid var(--accent-color);
+    outline-offset: 4px;
+}
+
+.leadSection,
+.readingDesk,
+.topicDirectory,
+.archive,
+.emptyState {
+    width: min(100%, 1320px);
+    margin-inline: auto;
+}
+
+.leadSection {
+    padding: clamp(74px, 9vw, 128px) clamp(20px, 4vw, 54px);
+}
+
+.sectionLabel {
+    display: flex;
+    justify-content: space-between;
+    gap: 20px;
+    margin-bottom: 18px;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-weight: 800;
+}
+
+.leadStory {
+    display: grid;
+    grid-template-columns: clamp(120px, 17vw, 220px) minmax(0, 1fr);
+    min-height: 620px;
+    color: var(--bg-primary);
+    background: var(--accent-color);
+    border-radius: 16px;
+    overflow: hidden;
+}
+
+.leadMarker {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 30px;
+    border-right: 1px solid color-mix(in srgb, var(--bg-primary) 24%, transparent);
+}
+
+.leadMarker span {
+    font-size: 0.9rem;
+    font-weight: 800;
+    writing-mode: vertical-rl;
+    transform: rotate(180deg);
+}
+
+.leadMarker strong {
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 4vw, 3.25rem);
+    font-weight: 400;
+    letter-spacing: -0.035em;
+    writing-mode: vertical-rl;
+    transform: rotate(180deg);
+}
+
+.leadCopy {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding: clamp(32px, 6vw, 72px);
+}
+
+.storyMeta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 18px;
+    font-size: 0.8rem;
+    font-weight: 800;
+}
+
+.leadCopy .storyMeta {
+    margin-bottom: auto;
+    padding-bottom: 70px;
+    color: color-mix(in srgb, var(--bg-primary) 70%, transparent);
+}
+
+.leadCopy h2 {
+    max-width: 13ch;
+    color: var(--bg-primary);
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 7vw, 6rem);
+    font-weight: 400;
+    line-height: 0.94;
+    letter-spacing: -0.04em;
+    text-align: left;
+    text-wrap: balance;
+}
+
+.leadCopy > p {
+    max-width: 68ch;
+    margin-top: 28px;
+    color: color-mix(in srgb, var(--bg-primary) 76%, transparent);
+    font-size: 1rem;
+    line-height: 1.7;
+}
+
+.leadCopy > a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 28px;
+    width: fit-content;
+    min-width: min(100%, 300px);
+    min-height: 52px;
+    margin-top: 34px;
+    padding: 14px 22px;
+    color: var(--text-primary);
+    background: var(--bg-primary);
+    border: 1px solid var(--bg-primary);
+    border-radius: 10px;
+    font-size: 0.9rem;
+    font-weight: 800;
+    transition: color 180ms ease, background-color 180ms ease, transform 180ms ease;
+}
+
+.leadCopy > a:hover {
+    color: var(--bg-primary);
+    background: var(--primary-color);
+    transform: translateY(-2px);
+}
+
+.readingDesk {
+    padding: clamp(90px, 11vw, 150px) clamp(20px, 4vw, 54px);
+    border-top: 1px solid var(--border-color);
+}
+
+.sectionHeading {
+    display: flex;
+    justify-content: space-between;
+    gap: 48px;
+    align-items: flex-end;
+    margin-bottom: clamp(46px, 7vw, 78px);
+}
+
+.sectionHeading h2,
+.topicDirectory > h2 {
+    max-width: 14ch;
+    color: inherit;
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 5.7vw, 5rem);
+    font-weight: 400;
+    line-height: 0.98;
+    letter-spacing: -0.03em;
+    text-align: left;
+}
+
+.sectionHeading > p {
+    max-width: 48ch;
+    color: var(--text-secondary);
+    line-height: 1.7;
+}
+
+.deskGrid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
+    gap: 24px;
+}
+
+.deskFeature {
+    display: flex;
+    flex-direction: column;
+    min-height: 580px;
+    padding: clamp(32px, 5vw, 64px);
+    color: var(--bg-primary);
+    background: var(--text-primary);
+    border-radius: 16px;
+}
+
+.deskFeature .storyMeta {
+    color: color-mix(in srgb, var(--bg-primary) 64%, transparent);
+}
+
+.deskFeature .storyMeta span:first-child {
+    color: var(--bg-primary);
+}
+
+.deskFeature h3 {
+    max-width: 14ch;
+    margin-top: auto;
+    color: var(--bg-primary);
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 5.7vw, 5rem);
+    font-weight: 400;
+    line-height: 0.98;
+    letter-spacing: -0.035em;
+    text-wrap: balance;
+}
+
+.deskFeature > p {
+    max-width: 58ch;
+    margin-top: 22px;
+    color: color-mix(in srgb, var(--bg-primary) 72%, transparent);
+    line-height: 1.7;
+}
+
+.deskFeature > a,
+.deskRow > a {
+    display: flex;
+    justify-content: space-between;
+    gap: 20px;
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid currentColor;
+    font-size: 0.8rem;
+    font-weight: 800;
+}
+
+.deskFeature > a {
+    color: var(--bg-primary);
+}
+
+.deskRail {
+    border-top: 1px solid var(--border-color);
+}
+
+.deskRow {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 18px 28px;
+    padding: 26px 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.deskRow .storyMeta {
+    grid-column: 1 / -1;
+    color: var(--text-tertiary);
+}
+
+.deskRow .storyMeta span:first-child {
+    color: var(--primary-color);
+}
+
+.deskRow h3 {
+    max-width: 22ch;
+    color: var(--text-primary);
+    font-size: clamp(1.5rem, 2.3vw, 2.15rem);
+    font-weight: 800;
+    line-height: 1.12;
+    letter-spacing: -0.025em;
+    text-wrap: balance;
+}
+
+.deskRow > a {
+    align-self: end;
+    min-width: 106px;
+    margin-top: 0;
+    color: var(--primary-color);
+}
+
+.topicDirectory {
+    display: grid;
+    grid-template-columns: minmax(260px, 0.75fr) minmax(0, 1.25fr);
+    gap: clamp(54px, 9vw, 130px);
+    padding: clamp(82px, 10vw, 140px) clamp(20px, 4vw, 54px);
+    color: var(--bg-primary);
+    background: var(--primary-color);
+    border-radius: 16px;
+}
+
+.topicDirectory > h2 {
+    color: var(--bg-primary);
+}
+
+.topicList {
+    border-top: 1px solid color-mix(in srgb, var(--bg-primary) 28%, transparent);
+}
+
+.topicList a {
+    display: flex;
+    justify-content: space-between;
+    gap: 28px;
+    min-height: 48px;
+    padding: 15px 0;
+    color: var(--bg-primary);
+    border-bottom: 1px solid color-mix(in srgb, var(--bg-primary) 28%, transparent);
+    font-size: 0.9rem;
+    font-weight: 800;
+    transition: background-color 180ms ease;
+}
+
+.topicList a:hover {
+    background: color-mix(in srgb, var(--bg-primary) 7%, transparent);
+}
+
+.topicList a span:first-child {
+    transition: transform 180ms ease;
+}
+
+.topicList a:hover span:first-child {
+    transform: translateX(8px);
+}
+
+.topicList a span:last-child {
+    color: color-mix(in srgb, var(--bg-primary) 62%, transparent);
+    font-size: 0.8rem;
+}
+
+.archive {
+    padding: clamp(90px, 11vw, 150px) clamp(20px, 4vw, 54px);
+}
+
+.archiveList {
+    border-top: 1px solid var(--border-color);
+}
+
+.archiveRow {
+    display: grid;
+    grid-template-columns: 62px minmax(135px, 0.36fr) minmax(0, 1.4fr) minmax(110px, 0.24fr);
+    gap: clamp(20px, 4vw, 56px);
+    align-items: start;
+    padding: 28px 0;
+    border-bottom: 1px solid var(--border-color);
+    scroll-margin-top: 96px;
+}
+
+.archiveNumber {
+    color: var(--text-tertiary);
+    font-family: var(--font-display);
+    font-size: 1rem;
+}
+
+.archiveDate {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 800;
+}
+
+.archiveDate span {
+    color: var(--primary-color);
+}
+
+.archiveTitle h3 {
+    max-width: 26ch;
+    color: var(--text-primary);
+    font-size: clamp(1.5rem, 2.3vw, 2.15rem);
+    font-weight: 800;
+    line-height: 1.12;
+    letter-spacing: -0.025em;
+    text-wrap: balance;
+}
+
+.archiveTitle p {
+    max-width: 64ch;
+    margin-top: 11px;
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    line-height: 1.7;
+}
+
+.archiveRow > a {
+    display: flex;
+    justify-content: space-between;
+    gap: 14px;
+    min-height: 44px;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 800;
+}
+
+.archiveRow > a span:last-child {
+    display: grid;
+    place-items: center;
+    width: 44px;
+    height: 44px;
+    margin-top: -8px;
+    color: var(--bg-primary);
+    background: var(--primary-color);
+    border-radius: 8px;
+    font-size: 1rem;
+    transition: background-color 180ms ease, transform 180ms ease;
+}
+
+.archiveRow > a:hover span:last-child {
+    background: var(--accent-color);
+    transform: translateY(-2px);
+}
+
+.emptyState {
+    padding: clamp(90px, 12vw, 160px) clamp(20px, 4vw, 54px);
+}
+
+.emptyState h2 {
+    max-width: 14ch;
+    color: var(--text-primary);
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 7vw, 6rem);
+    font-weight: 400;
+    line-height: 0.94;
+    letter-spacing: -0.035em;
+    text-align: left;
+}
+
+.emptyState p {
+    margin-top: 24px;
+    color: var(--text-secondary);
+}
+
+@media (max-width: 980px) {
+    .topicDirectory,
+    .deskGrid {
+        grid-template-columns: 1fr;
+    }
+
+    .deskFeature {
+        min-height: 520px;
+    }
+
+    .archiveRow {
+        grid-template-columns: 52px minmax(120px, 0.35fr) minmax(0, 1.35fr);
+    }
+
+    .archiveRow > a {
+        grid-column: 3;
+        max-width: 180px;
+    }
+}
+
+@media (max-width: 700px) {
+    .sectionHeading {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .leadStory {
+        grid-template-columns: 1fr;
+        min-height: 0;
+    }
+
+    .leadMarker {
+        flex-direction: row;
+        padding: 20px 24px;
+        border-right: 0;
+        border-bottom: 1px solid color-mix(in srgb, var(--bg-primary) 24%, transparent);
+    }
+
+    .leadMarker span,
+    .leadMarker strong {
+        writing-mode: initial;
+        transform: none;
+    }
+
+    .leadMarker strong {
+        font-size: 2rem;
+    }
+
+    .leadCopy {
+        min-height: 540px;
+        padding: 30px 24px;
+    }
+
+    .leadCopy h2 {
+        font-size: clamp(3rem, 14vw, 5rem);
+    }
+
+    .deskFeature {
+        min-height: 500px;
+        padding: 32px 24px;
+    }
+
+    .deskRow {
+        grid-template-columns: 1fr;
+    }
+
+    .deskRow > a {
+        min-width: 0;
+    }
+
+    .archiveRow {
+        grid-template-columns: 44px minmax(0, 1fr);
+        gap: 18px;
+    }
+
+    .archiveDate,
+    .archiveTitle,
+    .archiveRow > a {
+        grid-column: 2;
+    }
+
+    .archiveRow > a {
+        align-items: center;
+        max-width: none;
+    }
+}
+
+@media (max-width: 430px) {
+    .sectionLabel {
+        align-items: flex-end;
+    }
+
+    .leadCopy {
+        min-height: 500px;
+    }
+
+    .topicDirectory {
+        border-radius: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .leadCopy > a,
+    .topicList a,
+    .topicList a span:first-child,
+    .archiveRow > a span:last-child {
+        transition: none;
+    }
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link'
 import { PageHero } from '@/components/PageHero'
+import type { BlogPostMetadata } from '@/lib/markdown'
 import { getSortedPostsData } from '@/lib/markdown'
 import { createPageMetadata } from '@/lib/siteMetadata'
-import styles from '@/app/inner.module.css'
+import innerStyles from '@/app/inner.module.css'
+import styles from './blog.module.css'
 
 export const metadata = createPageMetadata({
   title: 'Field Notes — Matteo',
@@ -10,103 +12,249 @@ export const metadata = createPageMetadata({
   path: '/blog/',
 })
 
+function dateFromPost(date: string) {
+  return new Date(`${date}T00:00:00Z`)
+}
+
 function formatDate(date: string) {
-  return new Date(date).toLocaleDateString('en-US', {
+  return dateFromPost(date).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
+    timeZone: 'UTC',
   })
+}
+
+function formatMonthYear(date: string) {
+  return dateFromPost(date).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    timeZone: 'UTC',
+  })
+}
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
+function makeExcerpt(post: BlogPostMetadata, maxLength = 210) {
+  const title = post.title
+    .replace(/[\u00a0\u2009\u200a\u200b\u202f\u205f\u3000]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  let excerpt = post.excerpt
+    .replace(/[\u00a0\u2009\u200a\u200b\u202f\u205f\u3000]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/([.!?])(?=[A-Z])/g, '$1 ')
+    .trim()
+
+  if (excerpt.toLowerCase().startsWith(title.toLowerCase())) {
+    excerpt = excerpt.slice(title.length).replace(/^[\s:—-]+/, '')
+  }
+
+  if (excerpt.length <= maxLength) {
+    return excerpt
+  }
+
+  const shortened = excerpt.slice(0, maxLength)
+  const lastSpace = shortened.lastIndexOf(' ')
+
+  return `${shortened.slice(0, lastSpace > maxLength * 0.7 ? lastSpace : maxLength).trim()}…`
 }
 
 export default function BlogPage() {
   const posts = getSortedPostsData()
-  const [featuredPost, ...remainingPosts] = posts
-  const categoryCount = new Set(posts.map((post) => post.category)).size
+  const [featuredPost, ...otherPosts] = posts
+  const deskPosts = otherPosts.slice(0, 4)
+  const [deskFeature, ...deskRail] = deskPosts
+  const firstPostByCategory = new Map<string, string>()
+  const categoryCounts = new Map<string, number>()
+
+  for (const post of posts) {
+    categoryCounts.set(post.category, (categoryCounts.get(post.category) ?? 0) + 1)
+
+    if (!firstPostByCategory.has(post.category)) {
+      firstPostByCategory.set(post.category, post.slug)
+    }
+  }
+
+  const categories = [...categoryCounts.entries()].sort(([categoryA], [categoryB]) =>
+    categoryA.localeCompare(categoryB)
+  )
+  const firstPublishedYear = posts.at(-1)?.date.slice(0, 4)
 
   return (
-    <div className={styles.page}>
+    <div className={styles.blogPage}>
       <PageHero
         path="/blog"
-        title="Field notes, not content marketing."
-        description="Long-form lessons from cloud-native systems, developer relations, platform work, conferences, and the occasional industry funeral."
+        title="Field notes from the workbench."
+        description="Essays on building systems, growing technical communities, surviving conferences, and learning in public."
         tone="light"
         actions={
           featuredPost && (
-            <Link href={`/blog/${featuredPost.slug}`} className={styles.darkButton}>
-              Read the latest dispatch
+            <Link href={`/blog/${featuredPost.slug}`} className={innerStyles.darkButton}>
+              Read the latest field note
               <span aria-hidden="true">↗</span>
             </Link>
           )
         }
         aside={
-          <dl className={styles.heroSpecs}>
+          <dl className={innerStyles.heroSpecs}>
             <div>
-              <dt>Published</dt>
+              <dt>Archive</dt>
               <dd>{posts.length} field notes</dd>
             </div>
             <div>
               <dt>Coverage</dt>
-              <dd>{categoryCount} technical territories</dd>
+              <dd>{categories.length} subjects</dd>
             </div>
             <div>
-              <dt>Editorial policy</dt>
-              <dd>Useful before optimised</dd>
+              <dt>Latest issue</dt>
+              <dd>{featuredPost ? formatMonthYear(featuredPost.date) : 'Pending'}</dd>
+            </div>
+            <div>
+              <dt>Publishing since</dt>
+              <dd>{firstPublishedYear ?? 'Soon'}</dd>
             </div>
           </dl>
         }
       />
 
-      {featuredPost && (
-        <section className={styles.sectionDark} aria-labelledby="featured-note">
-          <div className={styles.sectionInner}>
-            <article className={styles.featuredPost}>
-              <div className={styles.featuredPostMeta}>
+      {featuredPost ? (
+        <section className={styles.leadSection} aria-label="Latest field note">
+          <div className={styles.sectionLabel}>
+            <span>Latest field note</span>
+            <span>Edition {String(posts.length).padStart(3, '0')}</span>
+          </div>
+          <article className={styles.leadStory}>
+            <div className={styles.leadMarker} aria-hidden="true">
+              <span>Latest</span>
+              <strong>{featuredPost.date.slice(0, 4)}</strong>
+            </div>
+            <div className={styles.leadCopy}>
+              <div className={styles.storyMeta}>
                 <span>{featuredPost.category}</span>
-                <span>{featuredPost.readTime}</span>
                 <time dateTime={featuredPost.date}>{formatDate(featuredPost.date)}</time>
+                <span>{featuredPost.readTime}</span>
               </div>
-              <div className={styles.featuredPostBody}>
-                <p>Latest dispatch</p>
-                <h2 id="featured-note">{featuredPost.title}</h2>
-                <p>{featuredPost.excerpt}</p>
-                <Link href={`/blog/${featuredPost.slug}`}>
-                  Read the full note
+              <h2 id="latest-note">{featuredPost.title}</h2>
+              <p>{makeExcerpt(featuredPost, 250)}</p>
+              <Link href={`/blog/${featuredPost.slug}`}>
+                Read the latest field note
+                <span aria-hidden="true">↗</span>
+              </Link>
+            </div>
+          </article>
+        </section>
+      ) : (
+        <section className={styles.emptyState} aria-labelledby="empty-blog">
+          <h2 id="empty-blog">The first field note is still on the workbench.</h2>
+          <p>New writing will appear here when it is ready to ship.</p>
+        </section>
+      )}
+
+      {deskPosts.length > 0 && (
+        <section className={styles.readingDesk} aria-labelledby="reading-desk">
+          <div className={styles.sectionHeading}>
+            <h2 id="reading-desk">The reading desk.</h2>
+            <p>
+              The newest arguments, post-mortems, guides, and annual dispatches,
+              selected from the top of the stack.
+            </p>
+          </div>
+          <div className={styles.deskGrid}>
+            {deskFeature && (
+              <article className={styles.deskFeature}>
+                <div className={styles.storyMeta}>
+                  <span>{deskFeature.category}</span>
+                  <time dateTime={deskFeature.date}>{formatDate(deskFeature.date)}</time>
+                </div>
+                <h3>{deskFeature.title}</h3>
+                <p>{makeExcerpt(deskFeature, 190)}</p>
+                <Link
+                  href={`/blog/${deskFeature.slug}`}
+                  aria-label={`Read ${deskFeature.title}`}
+                >
+                  <span>{deskFeature.readTime}</span>
                   <span aria-hidden="true">↗</span>
                 </Link>
-              </div>
-            </article>
+              </article>
+            )}
+            <div className={styles.deskRail}>
+              {deskRail.map((post) => (
+                <article key={post.slug} className={styles.deskRow}>
+                  <div className={styles.storyMeta}>
+                    <span>{post.category}</span>
+                    <time dateTime={post.date}>{formatDate(post.date)}</time>
+                  </div>
+                  <h3>{post.title}</h3>
+                  <Link href={`/blog/${post.slug}`} aria-label={`Read ${post.title}`}>
+                    <span>{post.readTime}</span>
+                    <span aria-hidden="true">↗</span>
+                  </Link>
+                </article>
+              ))}
+            </div>
           </div>
         </section>
       )}
 
-      <section className={styles.sectionSoft} aria-labelledby="all-notes">
-        <div className={styles.sectionInner}>
-          <div className={styles.sectionIntro}>
-            <h2 id="all-notes">The rest of the archive.</h2>
-            <p>Release notes from a career that keeps shipping in public.</p>
-          </div>
-          <div className={styles.postList}>
-            {remainingPosts.map((post) => (
-              <article key={post.slug} className={styles.postRow}>
-                <div className={styles.postMeta}>
-                  <span>{post.category}</span>
-                  <time dateTime={post.date}>{formatDate(post.date)}</time>
-                </div>
-                <div className={styles.postCopy}>
-                  <h3>{post.title}</h3>
-                  <p>{post.excerpt}</p>
-                </div>
-                <div className={styles.postAction}>
-                  <span>{post.readTime}</span>
-                  <Link href={`/blog/${post.slug}`} aria-label={`Read ${post.title}`}>
-                    <span aria-hidden="true">↗</span>
-                  </Link>
-                </div>
-              </article>
+      {categories.length > 0 && (
+        <nav className={styles.topicDirectory} aria-label="Browse field notes by topic">
+          <h2>Follow the thread, not the algorithm.</h2>
+          <div className={styles.topicList}>
+            {categories.map(([category, count]) => (
+              <a key={category} href={`#topic-${slugify(category)}`}>
+                <span>{category}</span>
+                <span>
+                  {count} {count === 1 ? 'note' : 'notes'} ↓
+                </span>
+              </a>
             ))}
           </div>
-        </div>
-      </section>
+        </nav>
+      )}
+
+      {posts.length > 0 && (
+        <section className={styles.archive} aria-labelledby="archive-title">
+          <div className={styles.sectionHeading}>
+            <h2 id="archive-title">The complete archive.</h2>
+            <p>Newest first. No paywall, no newsletter gate, no engagement bait.</p>
+          </div>
+          <div className={styles.archiveList}>
+            {posts.map((post, index) => {
+              const isCategoryAnchor = firstPostByCategory.get(post.category) === post.slug
+
+              return (
+                <article
+                  key={post.slug}
+                  id={isCategoryAnchor ? `topic-${slugify(post.category)}` : undefined}
+                  className={styles.archiveRow}
+                >
+                  <div className={styles.archiveNumber}>
+                    {String(posts.length - index).padStart(3, '0')}
+                  </div>
+                  <div className={styles.archiveDate}>
+                    <time dateTime={post.date}>{formatDate(post.date)}</time>
+                    <span>{post.category}</span>
+                  </div>
+                  <div className={styles.archiveTitle}>
+                    <h3>{post.title}</h3>
+                    <p>{makeExcerpt(post, 130)}</p>
+                  </div>
+                  <Link href={`/blog/${post.slug}`} aria-label={`Read ${post.title}`}>
+                    <span>{post.readTime}</span>
+                    <span aria-hidden="true">↗</span>
+                  </Link>
+                </article>
+              )
+            })}
+          </div>
+        </section>
+      )}
     </div>
   )
 }

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -149,6 +149,11 @@ test.describe('Static route experience', () => {
     await page.goto('/blog', { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByText('27 field notes', { exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Field notes from the workbench.' })).toBeVisible();
+    await expect(page.getByRole('region', { name: 'Latest field note' })).toBeVisible();
+    await expect(page.getByRole('region', { name: 'The reading desk' })).toBeVisible();
+    await expect(page.getByRole('navigation', { name: 'Browse field notes by topic' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'The complete archive.' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'My 2023 wrapped' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'I don’t like ChatGPT.' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Read I don’t like ChatGPT.' })).toHaveAttribute(


### PR DESCRIPTION
## Summary
- turn `/blog` into a responsive editorial landing page with a lead story and reading desk
- add topic navigation and preserve a complete chronological archive of all 27 posts
- normalize imported excerpts for cleaner previews while keeping static-export compatibility
- add browser coverage for the new front-page structure

## Validation
- `npm run lint`
- `npm run build`
- isolated Chromium checks at desktop and mobile widths
- targeted Playwright coverage for the blog page and full archive

Closes #93