### PR TITLE
[fix] add business details to footer

### DIFF
--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -37,7 +37,7 @@ const sections = [
   {
     title: 'Liability',
     paragraphs: [
-      <>To the extent permitted by law, Matteo is not liable for indirect loss resulting solely from using or being unable to use this website.</>,
+      <>To the extent permitted by law, SyncTune is not liable for indirect loss resulting solely from using or being unable to use this website.</>,
     ],
   },
   {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -60,7 +60,19 @@ export function Footer() {
         </div>
       </div>
       <div className={styles.footerBottom}>
-        <p>&copy; {currentYear} Matteo. No vendor lock-in.</p>
+        <div className={styles.footerIdentity}>
+          <p>&copy; {currentYear} SyncTune. No vendor lock-in.</p>
+          <dl className={styles.businessIdentifiers} aria-label="Business registration details">
+            <div>
+              <dt>KVK</dt>
+              <dd>91602289</dd>
+            </div>
+            <div>
+              <dt>VAT</dt>
+              <dd>NL004901960B70</dd>
+            </div>
+          </dl>
+        </div>
         <p>Designed as a product. Operated as a human.</p>
         <p className={styles.legalLinks}>
           <Link href="/privacy">Privacy</Link>

--- a/src/components/SiteShell.module.css
+++ b/src/components/SiteShell.module.css
@@ -227,8 +227,9 @@ footer.footer {
 }
 
 .footerBottom {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr) auto;
+    align-items: start;
     gap: 20px;
     width: min(100%, 1320px);
     margin: 0 auto;
@@ -238,9 +239,37 @@ footer.footer {
     font-size: 0.8rem;
 }
 
+.footerIdentity {
+    display: grid;
+    gap: 10px;
+}
+
+.businessIdentifiers {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 18px;
+    margin: 0;
+}
+
+.businessIdentifiers div {
+    display: flex;
+    gap: 6px;
+}
+
+.businessIdentifiers dt {
+    color: var(--text-primary);
+    font-weight: 700;
+}
+
+.businessIdentifiers dd {
+    margin: 0;
+    font-variant-numeric: tabular-nums;
+}
+
 .legalLinks {
     display: inline-flex;
     gap: 10px;
+    justify-self: end;
 }
 
 .legalLinks a {
@@ -344,7 +373,11 @@ footer.footer {
     }
 
     .footerBottom {
-        flex-direction: column;
+        grid-template-columns: 1fr;
+    }
+
+    .legalLinks {
+        justify-self: start;
     }
 }
 

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -607,6 +607,33 @@ test.describe('Static route experience', () => {
     }
   });
 
+  test('shows SyncTune registration details without footer overflow', async ({ page }) => {
+    for (const viewport of [
+      { width: 390, height: 844 },
+      { width: 1600, height: 900 },
+    ]) {
+      await page.setViewportSize(viewport);
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+      const footer = page.getByRole('contentinfo');
+      await expect(footer).toContainText(`© ${new Date().getFullYear()} SyncTune`);
+      const businessDetails = footer.locator(
+        'dl[aria-label="Business registration details"]'
+      );
+      await expect(businessDetails.getByText('KVK', { exact: true })).toBeVisible();
+      await expect(businessDetails.getByText('91602289', { exact: true })).toBeVisible();
+      await expect(businessDetails.getByText('VAT', { exact: true })).toBeVisible();
+      await expect(
+        businessDetails.getByText('NL004901960B70', { exact: true })
+      ).toBeVisible();
+
+      const hasOverflow = await footer.evaluate(
+        (element) => element.scrollWidth > element.clientWidth
+      );
+      expect(hasOverflow).toBe(false);
+    }
+  });
+
   test('calculates an advisory quote accessibly', async ({ page }) => {
     await page.goto('/pricing', { waitUntil: 'domcontentloaded' });
     await page.locator('html[data-hydrated="true"]').waitFor();


### PR DESCRIPTION
## Summary
- update footer copyright ownership to SyncTune
- add accessible KVK and VAT registration details with responsive layout
- align the terms liability identity and cover mobile/desktop footer rendering

## Validation
- npm run lint
- npm run build
- npx playwright test --project=chromium

Closes #98