### PR TITLE
[feature] add cookie and privacy policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project is a satirical product launch for Matteo Bianchi: a personal portfo
 - Production CSP, browser security headers, and asset caching configured through Vercel
 - Privacy-friendly traffic measurement through Vercel Web Analytics
 - Real-user Core Web Vitals collection through Vercel Speed Insights
+- Plain-language privacy and cookie policies that document the site’s actual Vercel data flows
 - An open-source proof ledger sourced from `src/data/projects.json`
 - A complete route system for field notes, changelog, portfolio, deployment history, pricing, legal, and support pages
 - A configurable `/links` endpoint manifest sourced from `src/data/links.ts`
@@ -131,6 +132,7 @@ src/
 │   ├── links/           # Configurable public link manifest
 │   ├── about/           # About page
 │   ├── careers/         # Careers page
+│   ├── cookies/         # Cookie policy
 │   ├── customers/       # Customers page
 │   ├── documentation/   # Documentation page
 │   ├── press/           # Press page

--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link'
+import { LegalDocument } from '@/components/LegalDocument'
+import { createPageMetadata } from '@/lib/siteMetadata'
+
+export const metadata = createPageMetadata({
+  title: 'Cookie Policy — Matteo',
+  description: 'The cookies and browser storage used by the Matteo website.',
+  path: '/cookies/',
+})
+
+const sections = [
+  {
+    title: 'Current cookie status',
+    paragraphs: [
+      <>The application code for <strong>mbianchi.dev</strong> does not set or read cookies. It also does not use local storage, session storage, IndexedDB, or another browser store to identify visitors.</>,
+      <>There are no advertising, personalization, or social-media tracking cookies on the site, and no cookie is required to browse its pages.</>,
+    ],
+  },
+  {
+    title: 'Vercel Web Analytics',
+    paragraphs: [
+      <>The site uses Vercel Web Analytics for anonymous, aggregate page-view statistics. Vercel states that this service does not use third-party cookies. Instead, it creates a hash from the incoming request and automatically discards the visitor session after 24 hours.</>,
+      <>The analytics integration is described in more detail in the <Link href="/privacy">Privacy Policy</Link> and Vercel’s <a href="https://vercel.com/docs/analytics/privacy-policy" target="_blank" rel="noopener noreferrer">Web Analytics privacy documentation</a>.</>,
+    ],
+  },
+  {
+    title: 'Vercel Speed Insights',
+    paragraphs: [
+      <>Vercel Speed Insights measures page performance through browser APIs and sends anonymous Web Vitals data to Vercel. The site does not use cookies or browser storage to operate this integration.</>,
+      <>The performance data involved is listed in the <Link href="/privacy">Privacy Policy</Link> and Vercel’s <a href="https://vercel.com/docs/speed-insights/privacy-policy" target="_blank" rel="noopener noreferrer">Speed Insights privacy documentation</a>.</>,
+    ],
+  },
+  {
+    title: 'External websites',
+    paragraphs: [
+      <>This site links to external services including GitHub, LinkedIn, Cal.com, Sessionize, and Speaker Deck. Those providers may use cookies after you navigate to their domains. Their controls and policies apply there; this site cannot read those cookies.</>,
+    ],
+  },
+  {
+    title: 'Your controls',
+    paragraphs: [
+      <>Because the current site does not use optional cookies, it does not display a consent banner. Blocking or deleting cookies in your browser will not prevent the site’s core pages from working.</>,
+      <>If optional cookies or comparable browser storage are introduced later, this page will be updated and any required choice will be presented before they are used.</>,
+    ],
+  },
+  {
+    title: 'Contact and changes',
+    paragraphs: [
+      <>Questions about this policy can be sent to <a href="mailto:privacy@mb-consulting.dev">privacy@mb-consulting.dev</a>.</>,
+      <>Material changes will be published on this page with a new effective date.</>,
+    ],
+  },
+]
+
+export default function CookiePolicyPage() {
+  return (
+    <LegalDocument
+      path="/cookies"
+      title="Cookies, minus the crumbs."
+      description="What this site stores in your browser, what its measurement tools do instead, and when a consent choice would appear."
+      summary="Short version: this site currently sets no cookies and uses no browser storage. Vercel provides anonymous analytics and performance measurement without third-party cookies."
+      effectiveDate="August 8, 2026"
+      sections={sections}
+    />
+  )
+}

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,56 +1,68 @@
+import Link from 'next/link'
 import { LegalDocument } from '@/components/LegalDocument'
 import { createPageMetadata } from '@/lib/siteMetadata'
 
 export const metadata = createPageMetadata({
   title: 'Privacy — Matteo',
-  description: 'A plain-language privacy policy for the Matteo static website.',
+  description: 'How the Matteo website handles hosting data, anonymous measurement, and direct contact.',
   path: '/privacy/',
 })
 
 const sections = [
   {
-    title: 'What this site collects',
+    title: 'Scope and site operator',
     paragraphs: [
-      <>This static website does not maintain a user database, account system, or first-party analytics profile.</>,
-      <>If you email Matteo, the message naturally contains the contact information and content you choose to send.</>,
+      <>This notice covers <strong>mbianchi.dev</strong> and the static pages served from that domain. Matteo Bianchi operates the site and can be reached at <a href="mailto:privacy@mb-consulting.dev">privacy@mb-consulting.dev</a>.</>,
+      <>The website has no accounts, sign-in, comments, checkout, newsletter form, or application database containing visitor profiles.</>,
     ],
   },
   {
-    title: 'Cookies and external resources',
+    title: 'Hosting and delivery data',
     paragraphs: [
-      <>The site does not intentionally set first-party tracking cookies.</>,
-      <>Fonts, images, code-hosting assets, and optional embeds are served by external providers. Those providers may receive normal request metadata such as your IP address and browser headers under their own policies.</>,
+      <>The site is built as a static export and hosted on Vercel. When your browser requests a page, Vercel receives the technical request data needed to deliver and protect it. That can include the IP address, requested URL, timestamp, referrer, user-agent, protocol, and request headers.</>,
+      <>The application code does not copy those requests into its own database. Vercel processes infrastructure data under its <a href="https://vercel.com/legal/privacy-notice" target="_blank" rel="noopener noreferrer">privacy notice</a> and its agreement with the site operator.</>,
     ],
   },
   {
-    title: 'How direct messages are used',
+    title: 'Anonymous audience measurement',
     paragraphs: [
-      <>Information sent by email or booking tools is used to respond, coordinate a conversation, or provide the service you requested. It is not sold.</>,
+      <>Vercel Web Analytics runs on every page to provide aggregate traffic statistics. The default integration records page views with data such as the route and URL, timestamp, referrer, filtered query parameters, coarse location, browser, operating system, device type, and analytics script version. No custom analytics events are configured.</>,
+      <>Vercel states that Web Analytics data is not tied to an individual or IP address, does not use third-party cookies, and uses a request-derived visitor hash whose session is discarded after 24 hours. See Vercel’s <a href="https://vercel.com/docs/analytics/privacy-policy" target="_blank" rel="noopener noreferrer">Web Analytics privacy documentation</a>.</>,
     ],
   },
   {
-    title: 'Retention and deletion',
+    title: 'Anonymous performance measurement',
     paragraphs: [
-      <>Messages are kept only as long as they remain useful for the conversation, professional relationship, or legal obligations. You may request deletion by contacting the address below.</>,
+      <>Vercel Speed Insights runs on each page load to measure real-user performance. It sends the route and URL, Web Vitals and their page attribution, network speed, browser, device type, operating system, country, SDK information, and server-received event time to Vercel.</>,
+      <>Vercel states that these data points are anonymous, are not associated with an individual or IP address, and cannot reconstruct a browsing session across pages. See Vercel’s <a href="https://vercel.com/docs/speed-insights/privacy-policy" target="_blank" rel="noopener noreferrer">Speed Insights privacy documentation</a>.</>,
     ],
   },
   {
-    title: 'External links',
+    title: 'Cookies and browser storage',
     paragraphs: [
-      <>Links may lead to GitHub, LinkedIn, Cal.com, Sessionize, Speaker Deck, and other external services. Their privacy practices are outside this site’s control.</>,
+      <>The website’s application code does not set or read cookies, local storage, session storage, or similar browser identifiers. The current Vercel Web Analytics integration does not use third-party cookies.</>,
+      <>The separate <Link href="/cookies">Cookie Policy</Link> explains the current implementation and what changes would require a consent choice.</>,
     ],
   },
   {
-    title: 'Your rights and contact',
+    title: 'Messages and external services',
     paragraphs: [
-      <>You may ask what information was received directly from you, request correction, or request deletion where applicable.</>,
-      <>Contact <a href="mailto:privacy@mb-consulting.dev">privacy@mb-consulting.dev</a> for privacy questions.</>,
+      <>If you email Matteo, the message includes the address, contact details, and content you choose to provide. It is used to answer you, coordinate a conversation, or provide the service you requested; the website itself does not store the message.</>,
+      <>Links can take you to services such as GitHub, LinkedIn, Cal.com, Sessionize, Speaker Deck, and other external websites. Once you follow a link, that provider’s privacy and cookie practices apply. Information you give those services is not automatically copied into this website.</>,
+    ],
+  },
+  {
+    title: 'Purposes, retention, and choices',
+    paragraphs: [
+      <>Technical request data is processed to deliver and secure the site. Aggregate analytics and performance data are used to understand which pages are useful and whether the site works well. This site does not run advertising, build cross-site profiles, or sell visitor data.</>,
+      <>Vercel documents the 24-hour lifetime of the Web Analytics visitor session hash. Retention of aggregate analytics, performance, and infrastructure records is otherwise controlled through Vercel’s service and account settings; the application code creates no separate copy.</>,
+      <>Direct messages can remain in the relevant email or scheduling service. You may ask for access, correction, or deletion of information you sent directly, subject to applicable obligations, by emailing <a href="mailto:privacy@mb-consulting.dev">privacy@mb-consulting.dev</a>.</>,
     ],
   },
   {
     title: 'Changes',
     paragraphs: [
-      <>Material changes will be published on this page with a new effective date. No twenty-page cookie banner will be deployed to announce them.</>,
+      <>Material changes will be published here with a new effective date. If the site later introduces optional cookies or comparable browser storage, the policy and consent controls will be updated before that technology is used.</>,
     ],
   },
 ]
@@ -60,9 +72,9 @@ export default function PrivacyPage() {
     <LegalDocument
       path="/privacy"
       title="Privacy without the surveillance novella."
-      description="A plain-language account of what this static site does, what external services may see, and how direct messages are handled."
-      summary="Short version: no user accounts, no first-party analytics database, no intentional tracking cookies, and no sale of personal data."
-      effectiveDate="July 13, 2026"
+      description="A plain-language account of the data involved in serving, measuring, and contacting this static website."
+      summary="Short version: no accounts or advertising profiles. Vercel handles hosting, anonymous page-view analytics, and anonymous performance metrics; direct contact stays with the service you use to send it."
+      effectiveDate="August 8, 2026"
       sections={sections}
     />
   )

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -65,6 +65,8 @@ export function Footer() {
         <p className={styles.legalLinks}>
           <Link href="/privacy">Privacy</Link>
           <span aria-hidden="true">·</span>
+          <Link href="/cookies">Cookie Policy</Link>
+          <span aria-hidden="true">·</span>
           <Link href="/terms">Terms of Service</Link>
         </p>
       </div>

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -22,6 +22,7 @@ const pages = [
   { name: 'support', path: '/support', title: 'Support — Matteo' },
   { name: 'status', path: '/status', title: 'Status — Matteo' },
   { name: 'privacy', path: '/privacy', title: 'Privacy — Matteo' },
+  { name: 'cookies', path: '/cookies', title: 'Cookie Policy — Matteo' },
   { name: 'terms', path: '/terms', title: 'Terms — Matteo' },
 ];
 
@@ -554,7 +555,7 @@ test.describe('Static route experience', () => {
     }
   });
 
-  test('navigates to Privacy and Terms from the footer', async ({ page }) => {
+  test('navigates to every policy from the footer', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     const footer = page.getByRole('contentinfo');
@@ -568,6 +569,17 @@ test.describe('Static route experience', () => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await page
       .getByRole('contentinfo')
+      .getByRole('link', { name: 'Cookie Policy' })
+      .click();
+    await expect(page).toHaveURL(/\/cookies\/?$/);
+    await expect(page).toHaveTitle('Cookie Policy — Matteo');
+    await expect(
+      page.getByRole('heading', { name: 'Cookies, minus the crumbs.' })
+    ).toBeVisible();
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page
+      .getByRole('contentinfo')
       .getByRole('link', { name: 'Terms of Service' })
       .click();
     await expect(page).toHaveURL(/\/terms\/?$/);
@@ -575,6 +587,22 @@ test.describe('Static route experience', () => {
     await expect(
       page.getByRole('heading', { name: 'Terms that fit on one reasonable page.' })
     ).toBeVisible();
+  });
+
+  test('documents the active measurement tools without claiming cookies', async ({ page }) => {
+    await page.goto('/privacy', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByRole('heading', { name: /Anonymous audience measurement/ })).toBeVisible();
+    await expect(page.getByText('Vercel Web Analytics runs on every page')).toBeVisible();
+    await expect(page.getByText('Vercel Speed Insights runs on each page load')).toBeVisible();
+    await expect(page.getByRole('main').getByRole('link', { name: 'Cookie Policy' })).toHaveAttribute(
+      'href',
+      '/cookies/'
+    );
+
+    await page.goto('/cookies', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByText(/does not set or read cookies/)).toBeVisible();
+    await expect(page.getByText(/does not use third-party cookies/).first()).toBeVisible();
   });
 
   test('uses the requested Product and Company footer taxonomy', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a dedicated cookie policy that reflects the site’s actual browser-storage behavior
- correct the privacy policy for Vercel hosting, Web Analytics, Speed Insights, and direct contact
- add discoverable footer navigation and browser coverage for both policies

## Validation
- `npm run lint`
- `npm run build`
- `CI=1 npx playwright test --config=playwright.local.config.ts` (41 passed; temporary local config used only to avoid another session on port 3000)
- desktop and mobile Playwright checks for navigation, overflow, console errors, cookies, local storage, and session storage

Closes #95