### PR TITLE
[feature] add CEO note About page

### DIFF
--- a/src/app/about/about.module.css
+++ b/src/app/about/about.module.css
@@ -1,0 +1,459 @@
+.page {
+    --paper: var(--text-primary);
+    --paper-ink: var(--bg-primary);
+    --paper-muted: color-mix(in srgb, var(--bg-primary) 70%, var(--text-primary));
+    --paper-cyan: color-mix(in srgb, var(--primary-color) 56%, var(--bg-primary));
+    min-height: 100vh;
+    color: var(--text-primary);
+    background: var(--bg-primary);
+}
+
+.page h1,
+.page h2,
+.page p {
+    text-wrap: pretty;
+}
+
+.page :where(section, article, div, blockquote) {
+    min-width: 0;
+}
+
+.page h2::after {
+    display: none;
+}
+
+.hero {
+    position: relative;
+    padding: clamp(64px, 9vw, 132px) clamp(20px, 5vw, 72px) clamp(72px, 10vw, 144px);
+    overflow: hidden;
+    background: var(--bg-primary);
+}
+
+.heroGrid {
+    position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1.12fr) minmax(320px, 0.72fr);
+    gap: clamp(48px, 9vw, 132px);
+    align-items: end;
+    width: min(100%, 1320px);
+    margin: 0 auto;
+}
+
+.heroCopy {
+    max-width: 820px;
+}
+
+.chapterKicker {
+    font-size: 0.9rem;
+    font-weight: 900;
+    letter-spacing: 0.13em;
+    text-transform: uppercase;
+}
+
+.hero h1 {
+    max-width: 8.5ch;
+    margin: 0;
+    color: var(--text-primary);
+    font-family: var(--font-display);
+    font-size: clamp(3.4rem, 7.6vw, 6rem);
+    font-weight: 400;
+    line-height: 0.94;
+    letter-spacing: -0.035em;
+}
+
+.lede {
+    max-width: 61ch;
+    margin: 34px 0 0;
+    color: var(--text-secondary);
+    font-size: 1rem;
+    line-height: 1.7;
+}
+
+.jumpLink {
+    display: inline-flex;
+    gap: 11px;
+    align-items: center;
+    margin-top: 38px;
+    padding: 14px 18px;
+    color: var(--bg-primary);
+    background: var(--primary-color);
+    border: 1px solid var(--primary-color);
+    border-radius: 10px;
+    font-weight: 900;
+    transition: transform 180ms ease, background-color 180ms ease, border-color 180ms ease;
+}
+
+.jumpLink:hover {
+    color: var(--bg-primary);
+    background: var(--accent-color);
+    border-color: var(--accent-color);
+    transform: translateY(-2px);
+}
+
+.portrait {
+    position: relative;
+    margin: 0;
+    padding: 14px;
+    background: color-mix(in srgb, var(--bg-card) 88%, transparent);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    box-shadow: 24px 28px 70px color-mix(in srgb, var(--bg-primary) 80%, transparent);
+}
+
+.portrait::before {
+    position: absolute;
+    top: -17px;
+    right: 26px;
+    z-index: 1;
+    padding: 7px 10px;
+    content: 'CEO / HUMAN';
+    color: var(--bg-primary);
+    background: var(--accent-color);
+    font-size: clamp(0.68rem, 1.2vw, 0.82rem);
+    font-weight: 900;
+    letter-spacing: 0.12em;
+    transform: rotate(2deg);
+}
+
+.portraitImage {
+    display: block;
+    width: 100%;
+    height: auto;
+    aspect-ratio: 4 / 5;
+    object-fit: cover;
+    object-position: 50% 34%;
+    border-radius: 10px;
+    filter: saturate(0.88) contrast(1.04);
+}
+
+.portrait figcaption {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 14px 4px 2px;
+    color: var(--text-tertiary);
+    font-size: 0.8rem;
+}
+
+.portrait figcaption span {
+    color: var(--text-primary);
+    font-weight: 800;
+}
+
+.letter {
+    color: var(--paper-ink);
+    background:
+        linear-gradient(90deg, transparent 0, transparent calc(50% - 1px), color-mix(in srgb, var(--paper-ink) 3.5%, transparent) 50%, transparent calc(50% + 1px)),
+        var(--paper);
+}
+
+.letterHeader,
+.chapter,
+.signoff {
+    width: min(100% - 40px, 1120px);
+    margin: 0 auto;
+}
+
+.letterHeader {
+    padding: clamp(82px, 10vw, 140px) 0;
+    border-bottom: 2px solid var(--paper-ink);
+}
+
+.letterHeader h2 {
+    max-width: 11ch;
+    margin: 0;
+    color: var(--paper-ink);
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 5.7vw, 5rem);
+    font-weight: 400;
+    line-height: 0.98;
+    letter-spacing: -0.03em;
+}
+
+.letterHeader div > p {
+    max-width: 66ch;
+    margin: 30px 0 0;
+    color: var(--paper-muted);
+    font-size: 1rem;
+    line-height: 1.7;
+}
+
+.chapter {
+    display: grid;
+    grid-template-columns: minmax(150px, 0.28fr) minmax(0, 1fr);
+    gap: clamp(40px, 8vw, 110px);
+    padding: clamp(66px, 8vw, 112px) 0;
+    border-bottom: 1px solid color-mix(in srgb, var(--paper-ink) 20%, transparent);
+}
+
+.chapterMarker {
+    position: relative;
+}
+
+.chapterMarker::before {
+    position: absolute;
+    top: 9px;
+    right: 0;
+    bottom: calc(-1 * clamp(66px, 8vw, 112px));
+    width: 1px;
+    content: '';
+    background: color-mix(in srgb, var(--paper-ink) 18%, transparent);
+}
+
+.chapterMarker span {
+    position: sticky;
+    top: 108px;
+    display: block;
+    width: fit-content;
+    padding: 7px 9px;
+    color: var(--paper);
+    background: var(--paper-ink);
+    font-size: 0.8rem;
+    font-weight: 900;
+    letter-spacing: 0.08em;
+    transform: rotate(-1deg);
+}
+
+.chapterBody {
+    max-width: 760px;
+}
+
+.chapterKicker {
+    display: none;
+    margin: 0 0 14px;
+    color: var(--paper-cyan);
+}
+
+.chapterBody h2 {
+    max-width: 15ch;
+    margin: 0 0 36px;
+    color: var(--paper-ink);
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 5.7vw, 5rem);
+    font-weight: 400;
+    line-height: 0.98;
+    letter-spacing: -0.03em;
+}
+
+.chapterBody > p {
+    margin: 0 0 25px;
+    color: color-mix(in srgb, var(--paper-ink) 88%, var(--paper));
+    font-size: 1rem;
+    line-height: 1.7;
+}
+
+.chapterBody blockquote {
+    position: relative;
+    margin: 42px 0;
+    padding: 30px clamp(24px, 5vw, 50px);
+    color: var(--text-primary);
+    background: var(--paper-ink);
+    border: 1px solid color-mix(in srgb, var(--primary-color) 58%, var(--paper-ink));
+    border-radius: 12px;
+}
+
+.chapterBody blockquote::before {
+    position: absolute;
+    top: -27px;
+    left: 14px;
+    content: '“';
+    color: var(--primary-color);
+    font-family: var(--font-display);
+    font-size: 5rem;
+    line-height: 1;
+}
+
+.chapterBody blockquote p {
+    margin: 0;
+    color: inherit;
+    font-size: clamp(1.5rem, 2.3vw, 2.15rem);
+    font-weight: 800;
+    line-height: 1.12;
+    letter-spacing: -0.025em;
+}
+
+.dialogue {
+    display: grid;
+    gap: 10px;
+}
+
+.dialogue strong {
+    margin-top: 16px;
+    color: var(--accent-color);
+    font-family: var(--font-display);
+    font-size: clamp(3rem, 5.7vw, 5rem);
+    font-weight: 400;
+    line-height: 0.98;
+    letter-spacing: -0.03em;
+}
+
+.dialogue span {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+}
+
+.marginNote {
+    margin: 36px 0;
+    padding: 24px;
+    color: color-mix(in srgb, var(--paper-ink) 86%, var(--paper));
+    background: color-mix(in srgb, var(--primary-color) 15%, var(--paper));
+    border: 1px solid color-mix(in srgb, var(--primary-color) 48%, var(--paper));
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 800;
+    line-height: 1.7;
+    transform: rotate(-0.4deg);
+}
+
+.warningNote {
+    background: color-mix(in srgb, var(--accent-color) 15%, var(--paper));
+    border-color: color-mix(in srgb, var(--accent-color) 46%, var(--paper-ink));
+}
+
+.signoff {
+    padding: clamp(84px, 11vw, 150px) 0;
+}
+
+.signoff > p {
+    max-width: 30ch;
+    margin: 0;
+    color: var(--paper-muted);
+    font-size: 1rem;
+    line-height: 1.7;
+}
+
+.signoff > strong {
+    display: block;
+    max-width: 10ch;
+    margin-top: 18px;
+    font-family: var(--font-display);
+    font-size: clamp(3.4rem, 7.6vw, 6rem);
+    font-weight: 400;
+    line-height: 0.94;
+    letter-spacing: -0.035em;
+}
+
+.signoff > div {
+    width: fit-content;
+    margin-top: 62px;
+    margin-left: auto;
+    text-align: right;
+}
+
+.signoff > div span {
+    display: block;
+    color: var(--paper-cyan);
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 4vw, 3.25rem);
+    line-height: 1;
+    letter-spacing: -0.035em;
+    transform: rotate(-4deg);
+}
+
+.signoff > div p {
+    margin-top: 12px;
+    color: var(--paper-muted);
+    font-size: 0.8rem;
+    font-weight: 900;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+}
+
+.page a:focus-visible {
+    outline: 3px solid var(--accent-color);
+    outline-offset: 4px;
+}
+
+@media (max-width: 900px) {
+    .heroGrid {
+        grid-template-columns: minmax(0, 1fr) minmax(270px, 0.72fr);
+        gap: 46px;
+    }
+
+    .hero h1 {
+        font-size: clamp(3.4rem, 7.6vw, 6rem);
+    }
+
+    .letterHeader,
+    .chapter {
+        grid-template-columns: 116px minmax(0, 1fr);
+        gap: 42px;
+    }
+}
+
+@media (max-width: 700px) {
+    .hero {
+        padding-top: 50px;
+    }
+
+    .heroGrid {
+        grid-template-columns: 1fr;
+    }
+
+    .hero h1 {
+        max-width: 9ch;
+        font-size: clamp(3.4rem, 17vw, 6rem);
+    }
+
+    .portrait {
+        width: min(100%, 470px);
+        margin-top: 20px;
+        box-shadow: 12px 12px 0 color-mix(in srgb, var(--primary-color) 17%, transparent);
+    }
+
+    .letter {
+        background: var(--paper);
+    }
+
+    .chapter {
+        grid-template-columns: 1fr;
+        gap: 0;
+    }
+
+    .chapterMarker {
+        display: none;
+    }
+
+    .chapterKicker {
+        display: block;
+    }
+
+    .chapterBody h2 {
+        margin-bottom: 30px;
+    }
+
+    .signoff > div {
+        margin-left: 0;
+        text-align: left;
+    }
+}
+
+@media (max-width: 420px) {
+    .portrait figcaption {
+        display: grid;
+        gap: 2px;
+    }
+
+    .chapterBody blockquote {
+        margin-right: 5px;
+    }
+}
+
+@media (max-width: 360px) {
+    .letterHeader h2,
+    .chapterBody h2 {
+        font-size: 2.15rem;
+    }
+
+    .signoff > strong {
+        max-width: 100%;
+        font-size: 2.15rem;
+        overflow-wrap: anywhere;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .jumpLink {
+        transition: none;
+    }
+}

--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -1,8 +1,8 @@
 import { createPageMetadata } from '@/lib/siteMetadata'
 
 export const metadata = createPageMetadata({
-  title: 'Product Internals — Matteo',
-  description: 'How Matteo combines platform engineering, Solutions Engineering, AI automation, software, open source, and technical education.',
+  title: 'A Note from Our CEO — Matteo',
+  description: 'Matteo Bianchi’s candid story from learning to code at 15 through software engineering, DevOps, startups, open source, and GitHub.',
   path: '/about/',
 })
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,188 +1,259 @@
-import Link from 'next/link'
-import { PageHero } from '@/components/PageHero'
 import { ResponsivePortrait } from '@/components/ResponsivePortrait'
-import styles from '@/app/inner.module.css'
+import styles from './about.module.css'
 
-const mission = [
+const chapters = [
   {
-    title: 'Start with real friction',
-    description: 'Understand the developer or customer workflow before choosing the platform, product surface, or automation.',
+    marker: 'Before 2015',
+    title: 'Curiosity beat the syllabus.',
+    body: (
+      <>
+        <p>
+          I was always passionate about computers and technology, but I started coding when I
+          was 15. I had switched from a scientific, mostly theoretical high school to what in
+          Italy is called a technical high school, where I learned the basics of programming
+          and computer science.
+        </p>
+        <p>
+          I was never a good student. School bored me and I never liked studying, but I was
+          always curious and loved learning new things, especially when they involved computers
+          or music. I played in several bands well before my tech career began. Music did not pay
+          the bills, so here I am, working in tech.
+        </p>
+        <blockquote>
+          <p>
+            Most of my professors told me I would never work in tech because I was not good
+            enough. I kept learning on my own anyway.
+          </p>
+        </blockquote>
+        <p>
+          Many people in my life were not happy with that choice either. They wanted me to go to
+          university, get a degree, and find a “real job” instead of “playing with computers.”
+          I wanted to work and learn by doing. I also tried to venture into esports, but that did
+          not go as expected either.
+        </p>
+      </>
+    ),
   },
   {
-    title: 'Automate for leverage',
-    description: 'Use AI and software to remove repeated work while keeping judgment, ownership, and observability with people.',
+    marker: '2015',
+    title: 'Production code before a driving licence.',
+    body: (
+      <>
+        <p>
+          I started my professional journey in 2015 as a web developer, writing production-grade
+          PHP before I had my driving licence.
+        </p>
+        <p>
+          As an employee, I started as a full-stack developer at a small company building
+          embedded software in C and internal tools in C#. Then I joined a promising local
+          startup, still as a full-stack developer, but back to PHP with a Laravel flavour.
+        </p>
+        <p>
+          The only other developer, who was also my mentor, left after just a few weeks. I found
+          myself as the only technical person in the building. Fun.
+        </p>
+        <aside className={styles.marginNote}>
+          I never really had a mentor. I had to figure things out by myself and do the genuine
+          “fake it till you make it” thing.
+        </aside>
+      </>
+    ),
   },
   {
-    title: 'Engineer for adoption',
-    description: 'Treat interfaces, documentation, enablement, and feedback loops as part of the system—not post-launch chores.',
+    marker: 'Milan → 2018',
+    title: 'Software engineering, then the dark side.',
+    body: (
+      <>
+        <p>
+          After high school I moved to Milan, switched languages to specialise in Java, and built
+          my back end as a Software Engineer. I climbed the ladder, worked on large-scale products
+          serving more than eight million users at the time—more than ten million today—and
+          eventually became a Senior Software Engineer.
+        </p>
+        <p>
+          Since I am fundamentally lazy, I learned to love automation. I started with Bash scripts
+          and moved into DevOps tools and practices.
+        </p>
+        <blockquote className={styles.dialogue}>
+          <p>“Do you know Kubernetes?”</p>
+          <p>“Yes, of course.”</p>
+          <strong>I was lying.</strong>
+          <span>It was 2018. In Italy, very few people knew what it was.</span>
+        </blockquote>
+        <p>
+          I joined the dark side of DevOps and Site Reliability Engineering, bringing the best of
+          my software engineering background with me. I led DevOps initiatives, improved DORA
+          metrics—we measured before changing—and helped multiple teams move from zero to GitOps.
+        </p>
+      </>
+    ),
   },
   {
-    title: 'Compound in public',
-    description: 'Contribute upstream, teach what works, and turn hard-won lessons into reusable open-source and community value.',
-  },
-]
-
-const departments = [
-  {
-    name: 'Platform mode',
-    role: 'Systems',
-    description: 'Builds cloud infrastructure, Kubernetes platforms, paved roads, and reliability into a usable developer product.',
-  },
-  {
-    name: 'Solutions mode',
-    role: 'Customers',
-    description: 'Connects discovery, architecture, demos, delivery, and field feedback without losing technical credibility.',
-  },
-  {
-    name: 'AI mode',
-    role: 'Automation',
-    description: 'Turns repeated workflows into assistants, agents, and tools with measurable outcomes and human ownership.',
-  },
-  {
-    name: 'Software mode',
-    role: 'Delivery',
-    description: 'Ships APIs, CLIs, services, and product interfaces across Go, Python, TypeScript, Rust, and React.',
-  },
-  {
-    name: 'Open-source mode',
-    role: 'Leverage',
-    description: 'Contributes upstream, maintains release infrastructure, and helps companies build credible open-source strategy.',
-  },
-  {
-    name: 'Education mode',
-    role: 'Adoption',
-    description: 'Uses talks, workshops, mentorship, and documentation to make complex technology understandable and reusable.',
-  },
-]
-
-const communityLinks = [
-  {
-    label: 'Speaking and events',
-    detail: 'Session history, upcoming appearances, and conference programme records.',
-    href: 'https://sessionize.com/mbianchidev/',
+    marker: '2021',
+    title: 'No ladder? Build another one.',
+    body: (
+      <>
+        <p>
+          Eventually I hit a ceiling, both at the company where I worked and in the Italian IT
+          landscape. Italy did not have a clear Individual Contributor ladder: in most companies,
+          you either became a manager or stayed at Senior. That was 2021. Things may have changed,
+          and I hope they have; I still have family and friends working in tech there.
+        </p>
+        <p>
+          So I became a freelance professional and something of a digital nomad. I wanted to scale
+          my impact on the industry and help more people and companies achieve their goals.
+        </p>
+        <p>
+          I took on far more clients than I could handle. That meant endless weeks, nights, and
+          weekends spent grinding. Yes, I made more money than ever before—and, honestly, more
+          than I have since. It was a ridiculous amount of money every month.
+        </p>
+        <p>
+          I coached and mentored people on DevOps principles and practices and, in hindsight, on
+          Platform Engineering before it was cool, Kubernetes included. I helped companies with
+          infrastructure, developer experience, CI/CD, DevSecOps, and the processes around them.
+        </p>
+        <p>
+          I also learned more front end, especially React. I always despised JavaScript, but
+          TypeScript made me like it a little more. It is still not my thing, but I can live with
+          it. Node.js is more fun than I expected; I will give you that. This joined Python and Go
+          in my main toolbox, with a pinch of C, C++, and C# from the past. PHP? Gone. I do not
+          want to touch it anymore. Sorry.
+        </p>
+      </>
+    ),
   },
   {
-    label: 'Talk catalogue',
-    detail: 'Slide decks covering cloud native, platform engineering, DevRel, and open source.',
-    href: 'https://speakerdeck.com/mbianchidev',
+    marker: '2023',
+    title: 'Cofounder, CTO, and a hard lesson.',
+    body: (
+      <>
+        <p>
+          After working across Europe as a digital nomad, I joined KubeLab in 2023 as a late
+          cofounder and CTO. I guided its pivot from a bootstrapped consultancy to a product
+          company.
+        </p>
+        <p>
+          It was a hell of a year. I enjoyed building a new company culture, revolutionising its
+          services, taking a product from zero to one end to end, and caring for my team until the
+          very end—even giving up my severance so theirs could be paid. It was only fair. Big tech
+          can definitely do better when laying people off for no reason.
+        </p>
+        <aside className={`${styles.marginNote} ${styles.warningNote}`}>
+          Note to self: equal ownership, or you are not a cofounder.
+        </aside>
+        <p>
+          Like many startups, we could not find product-market fit and had to step back. Failure
+          became the greatest teacher.
+        </p>
+      </>
+    ),
   },
   {
-    label: 'Open-source signal',
-    detail: 'Repositories, contributions, and the work behind the GitHub activity graph.',
-    href: '/portfolio',
+    marker: '2024 → 2026',
+    title: 'Community, customers, and cautious optimism.',
+    body: (
+      <>
+        <p>
+          I kept advocating for cloud native technologies. I started contributing to Kubernetes
+          upstream in 2024 and, as of 2026, I am still going. I have also been a CNCF Ambassador
+          since 2024, with a term set to run at least through 2028.
+        </p>
+        <p>
+          I strongly believe in the power of Platform Engineering. I co-authored the CNPA exam
+          with many smart people from the community, and I look forward to having a further impact
+          on the tech industry through my work.
+        </p>
+        <p>
+          After a short chapter at a Y Combinator W22 startup, where I joined as employee number
+          15 and became the effective Head of DevRel and Marketing—and the only DevRel, to be
+          fair—I joined GitHub as a Solutions Engineer.
+        </p>
+        <p>
+          Pre-sales is not really my thing, but I enjoy talking with customers and diving into the
+          nitty-gritty of complex, foundational products such as GitHub Actions.
+        </p>
+        <p>
+          I used to be an AI sceptic. Now I am a very cautious optimist, working on several hobby
+          projects I had zero time for before AI. I am also still leading a band in Berlin,
+          despite living somewhat close to Amsterdam and travelling fairly often to Italy and the
+          United States.
+        </p>
+      </>
+    ),
   },
 ]
 
 export default function About() {
   return (
     <div className={styles.page}>
-      <PageHero
-        path="/about"
-        title="Product internals. Deep engineering with customer-facing interfaces."
-        description="The startup is fictional. The operating model is real: build the system, translate the need, automate repeated work, and make the knowledge travel."
-        tone="dark"
-        actions={
-          <>
-            <Link href="#mission" className={styles.primaryButton}>
-              Read the operating principles
+      <section className={styles.hero} aria-labelledby="about-title">
+        <div className={styles.heroGrid}>
+          <div className={styles.heroCopy}>
+            <h1 id="about-title">A note from our CEO.</h1>
+            <p className={styles.lede}>
+              The title is part of the product metaphor. The story is not. This is how curiosity,
+              stubbornness, a few calculated risks, and more than one failure brought me here.
+            </p>
+            <a className={styles.jumpLink} href="#the-note">
+              Read the note
               <span aria-hidden="true">↓</span>
-            </Link>
-            <Link href="#community" className={styles.secondaryButton}>
-              Open community interfaces
-            </Link>
-          </>
-        }
-        aside={
-          <figure className={styles.portraitPanel}>
+            </a>
+          </div>
+
+          <figure className={styles.portrait}>
             <ResponsivePortrait
-              alt="Matteo Bianchi presenting at KCD Denmark"
-              sizes="(max-width: 700px) calc(100vw - 64px), (max-width: 980px) min(736px, calc(100vw - 120px)), 430px"
+              alt="Matteo Bianchi speaking on stage at KCD Denmark"
+              className={styles.portraitImage}
+              sizes="(max-width: 760px) calc(100vw - 40px), (max-width: 1080px) 42vw, 460px"
               priority
             />
-            <figcaption>Current production build / speaking interface enabled</figcaption>
+            <figcaption>
+              <span>Matteo Bianchi</span>
+              Speaking at KCD Denmark
+            </figcaption>
           </figure>
-        }
-      />
-
-      <section className={styles.sectionLight} aria-labelledby="mission-title">
-        <span id="mission" className={styles.anchor} aria-hidden="true" />
-        <div className={styles.sectionInner}>
-          <div className={styles.sectionIntro}>
-            <h2 id="mission-title">Mission parameters.</h2>
-            <p>What the product metaphor means when it stops being funny for a minute.</p>
-          </div>
-          <div className={styles.manifesto}>
-            {mission.map((item) => (
-              <article key={item.title} className={styles.manifestoRow}>
-                <h3>{item.title}</h3>
-                <p>{item.description}</p>
-              </article>
-            ))}
-          </div>
         </div>
       </section>
 
-      <section className={styles.visionSection} aria-labelledby="vision-title">
-        <div className={styles.sectionInner}>
-          <p>Long-range operating intent</p>
-          <h2 id="vision-title">
-            Build systems that solve the technical problem, earn adoption, and leave the team stronger.
-          </h2>
-          <p>
-            The best work connects engineering depth, customer signal, automation, and communication.
-            The goal is not to look cross-functional; it is to make those capabilities compound.
-          </p>
-        </div>
-      </section>
-
-      <section className={styles.sectionDark} aria-labelledby="community-title">
-        <span id="community" className={styles.anchor} aria-hidden="true" />
-        <div className={styles.sectionInner}>
-          <div className={styles.sectionIntro}>
-            <h2 id="community-title">Community interfaces.</h2>
-            <p>Direct routes to the public work. No cross-origin embed roulette required.</p>
-          </div>
-          <div className={styles.resourceGrid}>
-            {communityLinks.map((link) => {
-              const body = (
-                <>
-                  <strong>{link.label}</strong>
-                  <span>{link.detail}</span>
-                  <span aria-hidden="true">↗</span>
-                </>
-              )
-
-              return link.href.startsWith('http') ? (
-                <a key={link.label} href={link.href} target="_blank" rel="noopener noreferrer">
-                  {body}
-                </a>
-              ) : (
-                <Link key={link.label} href={link.href}>
-                  {body}
-                </Link>
-              )
-            })}
+      <article id="the-note" className={styles.letter} aria-label="A note from Matteo Bianchi">
+        <div className={styles.letterHeader}>
+          <div>
+            <h2>I learned by doing. Then I kept going.</h2>
+            <p>
+              This is not a polished founder myth. It is the longer, messier version: the boring
+              school days, the bluff that led to Kubernetes, the startup that did not find its
+              market, and the communities and people who made the work worth doing.
+            </p>
           </div>
         </div>
-      </section>
 
-      <section className={styles.sectionSoft} aria-labelledby="departments-title">
-        <div className={styles.sectionInner}>
-          <div className={styles.sectionIntro}>
-            <h2 id="departments-title">One human, six operating modes.</h2>
-            <p>Different contexts, shared architecture, no interdepartmental ticket required.</p>
-          </div>
-          <div className={styles.departmentGrid}>
-            {departments.map((department) => (
-              <article key={department.name} className={styles.department}>
-                <p>{department.role}</p>
-                <h3>{department.name}</h3>
-                <p>{department.description}</p>
-              </article>
-            ))}
+        <div className={styles.chapters}>
+          {chapters.map((chapter) => (
+            <section key={chapter.marker} className={styles.chapter} aria-labelledby={`chapter-${chapter.marker.replace(/\W+/g, '-').toLowerCase()}`}>
+              <div className={styles.chapterMarker} aria-hidden="true">
+                <span>{chapter.marker}</span>
+              </div>
+              <div className={styles.chapterBody}>
+                <p className={styles.chapterKicker}>{chapter.marker}</p>
+                <h2 id={`chapter-${chapter.marker.replace(/\W+/g, '-').toLowerCase()}`}>
+                  {chapter.title}
+                </h2>
+                {chapter.body}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <div className={styles.signoff}>
+          <p>What will I do in 2027 and beyond? Who knows.</p>
+          <strong>To be continued…</strong>
+          <div aria-label="Signed by Matteo Bianchi">
+            <span>Matteo</span>
+            <p>Matteo Bianchi</p>
           </div>
         </div>
-      </section>
+      </article>
     </div>
   )
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,7 +9,8 @@ import styles from './SiteShell.module.css'
 const navItems = [
   { href: '/#features', label: 'Product' },
   { href: '/customers', label: 'Customers' },
-  { href: '/blog', label: 'Blog' }
+  { href: '/about', label: 'About' },
+  { href: '/blog', label: 'Blog' },
 ]
 
 export function Header() {

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -5,7 +5,7 @@ import vercelConfig from '../vercel.json';
 const pages = [
   { name: 'homepage', path: '/', title: 'Matteo — The Human Platform' },
   { name: 'links', path: '/links', title: 'Links — Matteo' },
-  { name: 'about', path: '/about', title: 'Product Internals — Matteo' },
+  { name: 'about', path: '/about', title: 'A Note from Our CEO — Matteo' },
   { name: 'blog', path: '/blog', title: 'Field Notes — Matteo' },
   {
     name: 'blog-article',
@@ -229,11 +229,34 @@ test.describe('Static route experience', () => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     const navigation = page.getByRole('navigation', { name: 'Primary navigation' });
-    for (const label of ['Product', 'Customers', 'Blog']) {
+    for (const label of ['Product', 'Customers', 'About', 'Blog']) {
       await expect(navigation.getByRole('link', { name: label, exact: true })).toBeVisible();
     }
     await expect(navigation.getByRole('link', { name: 'Features', exact: true })).toHaveCount(0);
     await expect(navigation.getByRole('link', { name: 'Integrations', exact: true })).toHaveCount(0);
+  });
+
+  test('presents the About page as an accessible CEO note', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 844 });
+    await page.goto('/about', { waitUntil: 'domcontentloaded' });
+
+    await expect(page.getByRole('heading', { name: 'A note from our CEO.' })).toBeVisible();
+    await expect(page.getByRole('article', { name: 'A note from Matteo Bianchi' })).toBeVisible();
+    await expect(page.getByText('I was lying.', { exact: true })).toBeVisible();
+    await expect(page.getByText('To be continued…', { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole('img', { name: 'Matteo Bianchi speaking on stage at KCD Denmark' })
+    ).toBeVisible();
+
+    await page.locator('html[data-hydrated="true"]').waitFor();
+    await page.getByRole('button', { name: 'Open navigation menu' }).click();
+    const aboutLink = page
+      .getByRole('navigation', { name: 'Primary navigation' })
+      .getByRole('link', { name: 'About', exact: true });
+    await expect(aboutLink).toHaveAttribute('aria-current', 'page');
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth))
+      .toBe(true);
   });
 
   test('renders the Duck Runtime identity and app metadata', async ({ page }) => {


### PR DESCRIPTION
## Summary
- rebuild `/about` as a responsive, long-form “note from our CEO” using issue #97 as the source
- preserve the existing visual system, portrait, static export, and accessibility patterns
- add About to primary navigation and cover the route at a 320px viewport

## Validation
- `npm run lint`
- `npm run build`
- targeted Playwright coverage for the About route and navigation

Closes #97