### PR TITLE
[feature] Add generated sitemap and robots metadata

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from 'next'
+import { getRobotsDisallowRoutes } from '@/lib/seoRoutes'
+import { createSiteUrl, siteUrl } from '@/lib/siteMetadata'
+
+export const dynamic = 'force-static'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: getRobotsDisallowRoutes(),
+    },
+    sitemap: createSiteUrl('/sitemap.xml').toString(),
+    host: siteUrl.origin,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,42 @@
+import type { MetadataRoute } from 'next'
+import { getSortedPostsData } from '@/lib/markdown'
+import { getPublicStaticRoutes } from '@/lib/seoRoutes'
+import { createSiteUrl } from '@/lib/siteMetadata'
+
+export const dynamic = 'force-static'
+
+function reliableDate(date: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return undefined
+  }
+
+  const parsedDate = new Date(`${date}T00:00:00.000Z`)
+  return Number.isNaN(parsedDate.getTime()) || parsedDate.toISOString().slice(0, 10) !== date
+    ? undefined
+    : parsedDate
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const posts = getSortedPostsData()
+  const latestPostDate = posts
+    .map(({ date }) => reliableDate(date))
+    .filter((date): date is Date => date !== undefined)
+    .sort((left, right) => right.getTime() - left.getTime())[0]
+
+  const staticRoutes = getPublicStaticRoutes().map((route) => ({
+    url: createSiteUrl(route).toString(),
+    ...(route === '/blog/' && latestPostDate ? { lastModified: latestPostDate } : {}),
+  }))
+  const blogRoutes = posts.map((post) => {
+    const lastModified = reliableDate(post.date)
+
+    return {
+      url: createSiteUrl(`/blog/${post.slug}/`).toString(),
+      ...(lastModified ? { lastModified } : {}),
+    }
+  })
+
+  return [...staticRoutes, ...blogRoutes].sort((left, right) =>
+    left.url.localeCompare(right.url)
+  )
+}

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import pathRedirects from '@/data/redirects.json'
+
+const appDirectory = path.join(process.cwd(), 'src/app')
+const pageFilePattern = /^page\.(?:[jt]sx?)$/
+const redirectRoutes = new Set(pathRedirects.map(({ source }) => normalizeRoute(source)))
+
+function normalizeRoute(route: string) {
+  const normalized = route.replace(/^\/|\/$/g, '')
+
+  if (normalized === '') {
+    return '/'
+  }
+
+  return `/${normalized}/`
+}
+
+function isRouteGroup(segment: string) {
+  return segment.startsWith('(') && segment.endsWith(')')
+}
+
+function routeFromPageFile(pageFile: string) {
+  const relativeDirectory = path.relative(appDirectory, path.dirname(pageFile))
+  const segments = relativeDirectory === '' ? [] : relativeDirectory.split(path.sep)
+
+  if (
+    segments.some(
+      (segment) =>
+        segment.startsWith('[')
+        || segment.startsWith('@')
+        || segment.startsWith('_')
+        || (segment.startsWith('(') && !isRouteGroup(segment))
+    )
+  ) {
+    return null
+  }
+
+  const routeSegments = segments.filter((segment) => !isRouteGroup(segment))
+  return normalizeRoute(routeSegments.join('/'))
+}
+
+function hasNoIndexMetadata(pageFile: string) {
+  const sourceFiles = [pageFile]
+  let directory = path.dirname(pageFile)
+
+  while (directory.startsWith(appDirectory)) {
+    for (const extension of ['ts', 'tsx', 'js', 'jsx']) {
+      const layoutFile = path.join(directory, `layout.${extension}`)
+      if (fs.existsSync(layoutFile)) {
+        sourceFiles.push(layoutFile)
+      }
+    }
+
+    if (directory === appDirectory) {
+      break
+    }
+
+    directory = path.dirname(directory)
+  }
+
+  return sourceFiles.some((sourceFile) => {
+    const source = fs.readFileSync(sourceFile, 'utf8')
+    return (
+      source.includes('shortLinkMetadata')
+      || /\brobots\s*:\s*\{[\s\S]{0,500}?\bindex\s*:\s*false\b/.test(source)
+      || /\bnoindex\b/i.test(source)
+    )
+  })
+}
+
+function findPageFiles(directory: string): string[] {
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .flatMap((entry) => {
+      const entryPath = path.join(directory, entry.name)
+
+      if (entry.isDirectory()) {
+        return findPageFiles(entryPath)
+      }
+
+      return pageFilePattern.test(entry.name) ? [entryPath] : []
+    })
+}
+
+export function getPublicStaticRoutes() {
+  if (!fs.existsSync(appDirectory)) {
+    return []
+  }
+
+  const routeFiles = findPageFiles(appDirectory)
+    .map((pageFile) => ({ pageFile, route: routeFromPageFile(pageFile) }))
+    .filter(
+      (entry): entry is { pageFile: string; route: string } => entry.route !== null
+    )
+
+  return [
+    ...new Set(
+      routeFiles
+        .filter(({ route }) => !route.startsWith('/redirect/'))
+        .filter(({ route }) => !redirectRoutes.has(route))
+        .filter(({ pageFile }) => !hasNoIndexMetadata(pageFile))
+        .map(({ route }) => route)
+    ),
+  ].sort()
+}
+
+export function getRobotsDisallowRoutes() {
+  return [
+    '/redirect/',
+    ...[...redirectRoutes].filter((route) => route !== '/').sort(),
+  ]
+}

--- a/src/lib/siteMetadata.ts
+++ b/src/lib/siteMetadata.ts
@@ -2,6 +2,20 @@ import type { Metadata } from 'next'
 
 export const siteUrl = new URL('https://mbianchi.dev')
 
+function normalizePath(pathname: string) {
+  const basePath = process.env.NEXT_BASE_PATH?.replace(/^\/?/, '/').replace(/\/$/, '')
+  const pathWithoutBase =
+    basePath && basePath !== '/' && (pathname === basePath || pathname.startsWith(`${basePath}/`))
+      ? pathname.slice(basePath.length)
+      : pathname
+
+  return pathWithoutBase.startsWith('/') ? pathWithoutBase : `/${pathWithoutBase}`
+}
+
+export function createSiteUrl(pathname: string) {
+  return new URL(normalizePath(pathname), siteUrl)
+}
+
 interface PageMetadata {
   title: string
   description: string
@@ -13,7 +27,7 @@ export function createPageMetadata({
   description,
   path,
 }: PageMetadata): Metadata {
-  const canonical = new URL(path, siteUrl)
+  const canonical = createSiteUrl(path)
 
   return {
     title,

--- a/tests/pages.spec.ts
+++ b/tests/pages.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import pathRedirects from '../src/data/redirects.json';
+import { getSortedPostsData } from '../src/lib/markdown';
 import vercelConfig from '../vercel.json';
 
 const pages = [
@@ -48,6 +49,45 @@ test.describe('Short links', () => {
 });
 
 test.describe('Static route experience', () => {
+  test('publishes canonical sitemap and robots metadata routes', async ({ request }) => {
+    const sitemapResponse = await request.get('/sitemap.xml');
+    expect(sitemapResponse.ok()).toBe(true);
+
+    const sitemap = await sitemapResponse.text();
+    const sitemapUrls = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1]);
+    const expectedUrls = [
+      ...new Set([
+        ...pages.map(({ path }) =>
+          new URL(path.endsWith('/') ? path : `${path}/`, 'https://mbianchi.dev').toString()
+        ),
+        ...getSortedPostsData().map(({ slug }) => `https://mbianchi.dev/blog/${slug}/`),
+      ]),
+    ].sort();
+
+    expect(sitemap).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(sitemapUrls).toEqual(expectedUrls);
+    expect(new Set(sitemapUrls).size).toBe(sitemapUrls.length);
+
+    for (const redirect of pathRedirects) {
+      expect(sitemapUrls).not.toContain(
+        new URL(`${redirect.source}/`, 'https://mbianchi.dev').toString()
+      );
+    }
+    expect(sitemapUrls.some((url) => url.includes('/redirect/'))).toBe(false);
+
+    const robotsResponse = await request.get('/robots.txt');
+    expect(robotsResponse.ok()).toBe(true);
+
+    const robots = await robotsResponse.text();
+    expect(robots).toContain('User-Agent: *');
+    expect(robots).toContain('Allow: /');
+    expect(robots).toContain('Disallow: /redirect/');
+    expect(robots).toContain('Disallow: /secret/');
+    expect(robots).toContain('Sitemap: https://mbianchi.dev/sitemap.xml');
+    expect(robots).toContain('Host: https://mbianchi.dev');
+    expect(robots).not.toContain('/_next/');
+  });
+
   for (const page of pages) {
     test(`renders ${page.name}`, async ({ page: browserPage }) => {
       await browserPage.goto(page.path, { waitUntil: 'domcontentloaded' });


### PR DESCRIPTION
## Summary
- generate `sitemap.xml` from canonical App Router pages and Markdown blog content
- exclude redirects, noindex/private routes, and dynamic templates while preserving canonical custom-domain URLs
- generate `robots.txt` with canonical sitemap/host directives and noncanonical route exclusions
- cover metadata endpoints with focused Playwright assertions

## Validation
- `npm install` (0 vulnerabilities)
- `npm run lint`
- `npm run build`
- focused Playwright sitemap/robots test
- static export served locally with HTTP 200
- `NEXT_BASE_PATH=/mbianchi.dev npm run build` canonical URL check